### PR TITLE
ci: add External Issue Triage workflow (fixes CodeQL Actions analysis)

### DIFF
--- a/.github/workflows/issues-actions.yml
+++ b/.github/workflows/issues-actions.yml
@@ -1,0 +1,104 @@
+name: External Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if external contributor
+        id: contributor
+        run: |
+          case "${{ github.event.issue.author_association }}" in
+            OWNER)
+              echo "external=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "external=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Create Notion task
+        id: notion
+        if: steps.contributor.outputs.external == 'true'
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          REPO: ${{ github.repository }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          jq -n \
+            --arg db "$NOTION_DATABASE_ID" \
+            --arg title "$ISSUE_TITLE" \
+            --arg url "$ISSUE_URL" \
+            --arg repo "$REPO" \
+            --arg author "$ISSUE_AUTHOR" \
+            '{
+              parent: { database_id: $db },
+              properties: {
+                "Task name": {
+                  title: [ { text: { content: $title } } ]
+                }
+              },
+              children: [
+                {
+                  object: "block",
+                  type: "paragraph",
+                  paragraph: {
+                    rich_text: [
+                      { text: { content: ("Repo: " + $repo + "  ·  Author: " + $author) } }
+                    ]
+                  }
+                },
+                {
+                  object: "block",
+                  type: "bookmark",
+                  bookmark: { url: $url }
+                }
+              ]
+            }' > notion.json
+
+          response="$(curl -sS -X POST https://api.notion.com/v1/pages \
+            -H "Authorization: Bearer $NOTION_TOKEN" \
+            -H "Notion-Version: 2022-06-28" \
+            -H "Content-Type: application/json" \
+            --data @notion.json)"
+
+          notion_url="$(echo "$response" | jq -r '.url // empty')"
+          if [ -z "$notion_url" ]; then
+            echo "Notion page creation failed:" >&2
+            echo "$response" >&2
+            exit 1
+          fi
+          echo "url=$notion_url" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Google Chat
+        if: steps.contributor.outputs.external == 'true'
+        env:
+          GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+          REPOSITORY: ${{ github.repository }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          NOTION_URL: ${{ steps.notion.outputs.url }}
+        run: |
+          payload="$(jq -n \
+            --arg repository "$REPOSITORY" \
+            --arg title "$ISSUE_TITLE" \
+            --arg author "$ISSUE_AUTHOR" \
+            --arg url "$ISSUE_URL" \
+            --arg notion "$NOTION_URL" \
+            '{text: ("🚨 New external GitHub issue\n\nRepository: " + $repository + "\nTitle: " + $title + "\nAuthor: " + $author + "\nIssue: " + $url + "\nNotion task: " + $notion)}'
+          )"
+
+          curl -X POST "$GOOGLE_CHAT_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data "$payload"


### PR DESCRIPTION
`main` has no `.github/workflows/*.yml`, so CodeQL's default-setup **Analyze (actions)** job fails with `no source code seen during build` (exit 32) — visible on the latest pushes to main. JS/TS analysis and Socket pass; only the Actions analyzer errors because it has nothing to scan.

This restores `.github/workflows/issues-actions.yml` (External Issue Triage, originally from #33) to `main`, which both re-enables the triage automation and gives the Actions analyzer a workflow to process.

Alternative if you'd rather not scan Actions at all: disable the `actions` language in the repo's CodeQL default setup. This PR takes the keep-the-workflow route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)