### PR TITLE
near-intents: external-wallet sign-in fix, explorer link fallbacks, side-by-side layout

### DIFF
--- a/near-intents/README.md
+++ b/near-intents/README.md
@@ -47,6 +47,9 @@ ONECLICK_JWT=...                                    # Optional, server-side only
 Sign-in is restricted to **email** and **external wallet**. The wallet option only
 appears when `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` is set (free at
 [cloud.reown.com](https://cloud.reown.com)); without it, email sign-in is used.
+External wallet sign-in is EVM-only (WalletConnect `eip155`): multichain wallets
+like Phantom connect through their EVM accounts, and Solana-only wallets cannot
+pair — Solana is supported as a *destination* via the recipient address.
 
 ## 4. Install & Start
 
@@ -67,7 +70,9 @@ pnpm dev
 - **Openfort embedded wallets** with email/social authentication
 - **Single-deposit UX** — solvers handle routing and settlement; no NEAR keys needed
 - **Gas sponsorship** with Openfort policies (optional)
-- **Live status tracking** with explorer links
+- **Live status tracking** with explorer links — the 1Click status response's
+  `explorerUrl` is only trusted when absolute; otherwise links fall back to a
+  per-chain explorer map (origin and destination), or show the raw hash
 
 ## Notes
 

--- a/near-intents/src/app/page.tsx
+++ b/near-intents/src/app/page.tsx
@@ -5,7 +5,7 @@ import SwapFlow from "@/features/near-intents/components/SwapFlow";
 
 export default function Main() {
   return (
-    <PageLayout>
+    <PageLayout maxWidth="5xl">
       <SwapFlow />
     </PageLayout>
   );

--- a/near-intents/src/components/ui/page-layout.tsx
+++ b/near-intents/src/components/ui/page-layout.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 
 interface PageLayoutProps {
   children: ReactNode;
-  maxWidth?: "sm" | "lg" | "xl";
+  maxWidth?: "sm" | "lg" | "xl" | "5xl";
   className?: string;
 }
 
@@ -16,6 +16,7 @@ export function PageLayout({
     sm: "max-w-sm",
     lg: "max-w-lg",
     xl: "max-w-xl",
+    "5xl": "max-w-5xl",
   };
 
   return (

--- a/near-intents/src/features/near-intents/components/StatusTracker.tsx
+++ b/near-intents/src/features/near-intents/components/StatusTracker.tsx
@@ -2,7 +2,7 @@
 
 import { CheckCircle2, Clock, Loader2, XCircle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
-import { getExplorerUrl } from "@/lib/utils";
+import { getExplorerUrl, resolveTxExplorerUrl } from "@/lib/utils";
 import type {
   ExecutionStatusResponse,
   SwapAsset,
@@ -14,6 +14,7 @@ interface StatusTrackerProps {
   detail: ExecutionStatusResponse | null;
   depositTxHash: string | null;
   fromAsset: SwapAsset;
+  toAsset: SwapAsset | null;
 }
 
 const STAGES: { key: SwapStatus; label: string }[] = [
@@ -37,6 +38,7 @@ export default function StatusTracker({
   detail,
   depositTxHash,
   fromAsset,
+  toAsset,
 }: StatusTrackerProps) {
   const current = status ?? "PENDING_DEPOSIT";
   const rank = STAGE_RANK[current];
@@ -98,16 +100,22 @@ export default function StatusTracker({
 
         <div className="space-y-2 border-t border-border pt-4 text-sm">
           {depositExplorer && (
-            <TxRow label="Deposit transaction" href={depositExplorer} />
+            <TxRow label="Deposit transaction" hash={depositTxHash ?? ""} href={depositExplorer} />
           )}
           {originTxs.map((tx) => (
-            <TxRow key={tx.hash} label="Origin chain" href={tx.explorerUrl} />
+            <TxRow
+              key={tx.hash}
+              label="Origin chain"
+              hash={tx.hash}
+              href={resolveTxExplorerUrl(tx, fromAsset.blockchain)}
+            />
           ))}
           {destinationTxs.map((tx) => (
             <TxRow
               key={tx.hash}
               label="Destination chain"
-              href={tx.explorerUrl}
+              hash={tx.hash}
+              href={resolveTxExplorerUrl(tx, toAsset?.blockchain)}
             />
           ))}
         </div>
@@ -116,18 +124,32 @@ export default function StatusTracker({
   );
 }
 
-function TxRow({ label, href }: { label: string; href: string }) {
+function TxRow({
+  label,
+  hash,
+  href,
+}: {
+  label: string;
+  hash: string;
+  href: string | null;
+}) {
   return (
     <div className="flex items-center justify-between gap-4">
       <span className="text-muted-foreground">{label}</span>
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400"
-      >
-        View
-      </a>
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400"
+        >
+          View
+        </a>
+      ) : (
+        <span className="font-mono text-xs" title={hash}>
+          {hash.slice(0, 8)}…{hash.slice(-6)}
+        </span>
+      )}
     </div>
   );
 }

--- a/near-intents/src/features/near-intents/components/SwapFlow.tsx
+++ b/near-intents/src/features/near-intents/components/SwapFlow.tsx
@@ -28,9 +28,11 @@ export default function SwapFlow() {
     (TERMINAL_STATUSES as readonly string[]).includes(state.status);
 
   return (
-    <main className="flex flex-1 items-center justify-center p-6">
-      <div className="flex w-full max-w-md flex-col items-center gap-6">
+    <main className="flex flex-1 items-center justify-center">
+      <div className="grid w-full items-center gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] lg:gap-10">
         <CoBrandHero />
+
+        <div className="flex w-full flex-col items-center gap-4 justify-self-center lg:max-w-md">
 
         {isStatusLoading ? (
           <InfoCard>Loading wallet…</InfoCard>
@@ -86,6 +88,7 @@ export default function SwapFlow() {
                 detail={state.statusDetail}
                 depositTxHash={state.depositTxHash}
                 fromAsset={state.fromAsset}
+                toAsset={state.toAsset}
               />
             )}
 
@@ -102,16 +105,17 @@ export default function SwapFlow() {
           </>
         )}
 
-        {state.error && (
-          <Card className="w-full max-w-md border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950">
-            <CardContent className="flex items-center gap-3 p-4">
-              <AlertTriangle className="h-5 w-5 text-red-500" />
-              <p className="text-sm text-red-700 dark:text-red-300">
-                {state.error}
-              </p>
-            </CardContent>
-          </Card>
-        )}
+          {state.error && (
+            <Card className="w-full max-w-md border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950">
+              <CardContent className="flex items-center gap-3 p-4">
+                <AlertTriangle className="h-5 w-5 text-red-500" />
+                <p className="text-sm text-red-700 dark:text-red-300">
+                  {state.error}
+                </p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
       </div>
     </main>
   );

--- a/near-intents/src/features/near-intents/components/SwapForm.tsx
+++ b/near-intents/src/features/near-intents/components/SwapForm.tsx
@@ -64,17 +64,9 @@ export default function SwapForm({
   return (
     <div className="w-full max-w-md">
       <div className="rounded-2xl border border-border bg-card p-6 text-card-foreground shadow-lg">
-        <div className="mb-6 text-center">
-          <h1 className="mb-2 text-2xl font-bold">Cross-Chain Swap</h1>
-          <p className="text-sm text-muted-foreground">
-            Send from any EVM chain, receive on 30+ chains — including Solana,
-            Bitcoin and more
-          </p>
-          {walletAddress && (
-            <div className="mt-3">
-              <FundWallet walletAddress={walletAddress} />
-            </div>
-          )}
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold">Swap</h2>
+          {walletAddress && <FundWallet walletAddress={walletAddress} />}
         </div>
 
         <AssetField

--- a/near-intents/src/features/near-intents/components/co-branding.tsx
+++ b/near-intents/src/features/near-intents/components/co-branding.tsx
@@ -69,13 +69,18 @@ export function CoBrandHero({ className }: { className?: string }) {
         className
       )}
     >
-      <div className="flex flex-col items-center gap-4 text-center">
-        <CoBrandLogos />
+      <div className="flex flex-col items-center gap-4 text-center lg:items-start lg:text-left">
+        <CoBrandLogos className="lg:justify-start" />
+        <h1 className="text-2xl font-bold">Cross-Chain Swap</h1>
         <p className="text-sm text-muted-foreground max-w-sm">
           This recipe pairs Openfort&apos;s embedded wallets with NEAR
           Intents&apos; 1Click API. Your wallet signs a single deposit on the
           origin chain and a network of solvers settles the swap on the
           destination chain.
+        </p>
+        <p className="text-sm text-muted-foreground max-w-sm">
+          Send from any EVM chain, receive on 30+ chains — including Solana,
+          Bitcoin and more.
         </p>
       </div>
     </section>

--- a/near-intents/src/features/openfort/hooks/use-openfort-wallet.ts
+++ b/near-intents/src/features/openfort/hooks/use-openfort-wallet.ts
@@ -15,19 +15,23 @@ export interface OpenfortWalletState {
 export const useOpenfortWallet = (): OpenfortWalletState => {
   const wallet = useEthereumEmbeddedWallet();
   const { user, isAuthenticated } = useUser();
-  const { address } = useAccount();
+  const { address, status: accountStatus } = useAccount();
   const chainId = useChainId();
 
   const walletAddress = address ?? "";
-  const isConnected = wallet.status === "connected" && isAuthenticated;
-  const isReady = !wallet.isLoading && isConnected && !!walletAddress;
+  // Sign-in can use an Openfort embedded wallet or an external wallet (SIWE).
+  // Both surface through wagmi, so the wagmi account is the connection source
+  // of truth — the embedded-wallet status alone would never report external
+  // wallets as connected.
+  const isConnected = accountStatus === "connected" && isAuthenticated;
+  const isReady = isConnected && !!walletAddress;
 
   return {
     address: walletAddress,
     chainId,
     isReady,
     isConnected,
-    isStatusLoading: wallet.isLoading,
+    isStatusLoading: wallet.isLoading && !isConnected,
     isAuthenticated,
     playerName:
       user?.name ||

--- a/near-intents/src/lib/utils.ts
+++ b/near-intents/src/lib/utils.ts
@@ -28,6 +28,56 @@ export const getExplorerUrl = (txHash: string, chainId?: number) => {
   return explorers[chainId] || null;
 };
 
+// Explorer tx-URL builders keyed by 1Click blockchain identifiers. Origin
+// chains are always EVM, but destinations can be any chain NEAR Intents
+// supports, so non-EVM explorers are included too.
+const EXPLORER_BY_BLOCKCHAIN: Record<string, (txHash: string) => string> = {
+  eth: (tx) => `https://etherscan.io/tx/${tx}`,
+  base: (tx) => `https://basescan.org/tx/${tx}`,
+  arb: (tx) => `https://arbiscan.io/tx/${tx}`,
+  op: (tx) => `https://optimistic.etherscan.io/tx/${tx}`,
+  pol: (tx) => `https://polygonscan.com/tx/${tx}`,
+  avax: (tx) => `https://snowtrace.io/tx/${tx}`,
+  bsc: (tx) => `https://bscscan.com/tx/${tx}`,
+  gnosis: (tx) => `https://gnosisscan.io/tx/${tx}`,
+  scroll: (tx) => `https://scrollscan.com/tx/${tx}`,
+  bera: (tx) => `https://berascan.com/tx/${tx}`,
+  sol: (tx) => `https://solscan.io/tx/${tx}`,
+  btc: (tx) => `https://mempool.space/tx/${tx}`,
+  near: (tx) => `https://nearblocks.io/txns/${tx}`,
+  tron: (tx) => `https://tronscan.org/#/transaction/${tx}`,
+  ton: (tx) => `https://tonviewer.com/transaction/${tx}`,
+  xrp: (tx) => `https://xrpscan.com/tx/${tx}`,
+  doge: (tx) => `https://blockchair.com/dogecoin/transaction/${tx}`,
+  ltc: (tx) => `https://blockchair.com/litecoin/transaction/${tx}`,
+  bch: (tx) => `https://blockchair.com/bitcoin-cash/transaction/${tx}`,
+  zec: (tx) => `https://blockchair.com/zcash/transaction/${tx}`,
+  dash: (tx) => `https://blockchair.com/dash/transaction/${tx}`,
+  sui: (tx) => `https://suiscan.xyz/mainnet/tx/${tx}`,
+  stellar: (tx) => `https://stellar.expert/explorer/public/tx/${tx}`,
+  aptos: (tx) => `https://explorer.aptoslabs.com/txn/${tx}?network=mainnet`,
+  cardano: (tx) => `https://cardanoscan.io/transaction/${tx}`,
+  starknet: (tx) => `https://starkscan.co/tx/${tx}`,
+};
+
+/**
+ * Resolves the explorer link for a transaction reported by the 1Click status
+ * endpoint. The API sometimes returns an empty or relative `explorerUrl`; a
+ * relative href would silently resolve against this app's own origin, so only
+ * absolute http(s) URLs are trusted and everything else falls back to a
+ * per-blockchain explorer (or null, in which case no link is rendered).
+ */
+export const resolveTxExplorerUrl = (
+  tx: { hash: string; explorerUrl?: string },
+  blockchain?: string
+): string | null => {
+  if (tx.explorerUrl && /^https?:\/\//.test(tx.explorerUrl)) {
+    return tx.explorerUrl;
+  }
+  const build = blockchain ? EXPLORER_BY_BLOCKCHAIN[blockchain] : undefined;
+  return build ? build(tx.hash) : null;
+};
+
 export const formatAmount = (amount: string, decimals: number) => {
   try {
     const value = Number(amount) / 10 ** decimals;


### PR DESCRIPTION
## What

Three fixes to the NEAR Intents recipe:

**External-wallet sign-in no longer stalls.** The swap gate required `useEthereumEmbeddedWallet().status === 'connected'`, which never happens for external wallets — after WalletConnect pairing + SIWE the user stayed stuck on the sign-in card. The connection check now keys on the wagmi account status, which both the embedded wallet (via `OpenfortWagmiBridge`) and external connectors surface through. The email/embedded flow is unchanged: wagmi only reports connected once the embedded wallet is recovered.

**Explorer links no longer point at the app's own origin.** The 1Click status response sometimes returns an empty or relative `explorerUrl`; `<a href="">` resolved to localhost. Links now only trust absolute http(s) URLs from the API and otherwise fall back to a per-blockchain explorer map covering the six origin EVM chains plus common destinations (Solana, Bitcoin, NEAR, Tron, TON, XRP, Sui, Stellar, Aptos, Cardano, Starknet, Blockchair family). Destination links resolve on the destination chain via a new `toAsset` prop; when no explorer is known the truncated hash is shown instead of a dead link.

**Swap flow fits the viewport.** The co-brand description moved into a side column next to the swap card on lg+ screens, and the swap card header collapsed to a single row. Verified at 1280×720: page scroll height equals the viewport with the form rendered. Mobile stacks as before.

README updated to document the EVM-only external-wallet scope (Solana is a destination via recipient address) and the explorer fallback behavior.

## Verification

- `tsc --noEmit`, `next lint`, and `next build` pass
- Email sign-in and swap flow exercised on the dev server; layout verified headless at 1280×720 (signed-out and form states)
- External-wallet sign-in pending a manual WalletConnect run-through before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)