### PR TITLE
Add confidential swaps to NEAR Intents recipe

### DIFF
--- a/near-intents/.env.example
+++ b/near-intents/.env.example
@@ -1,0 +1,23 @@
+# Openfort Configuration (from https://dashboard.openfort.io)
+NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY=
+NEXT_PUBLIC_OPENFORT_SHIELD_PUBLISHABLE_KEY=
+NEXT_PUBLIC_OPENFORT_FEE_SPONSORSHIP_ID=
+NEXT_PUBLIC_OPENFORT_DEFAULT_CHAIN_ID=8453
+
+# WalletConnect project ID (free at https://cloud.reown.com)
+# Required to enable external-wallet sign-in. Without it, only email sign-in shows.
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
+
+# NEAR Intents 1Click API (https://docs.near-intents.org)
+# Optional JWT — without it a 0.2% fee applies and rate limits are lower.
+# Request one at https://partners.near-intents.org.
+# Server-side only: do NOT prefix with NEXT_PUBLIC_ (it must never reach the browser).
+# REQUIRED for confidential swaps (the confidential API rejects unauthenticated calls).
+ONECLICK_JWT=
+# Optional base URL override; defaults to https://1click.chaindefuser.com
+ONECLICK_BASE_URL=
+
+# Confidential swaps (NEAR Confidential Intents). Set to `true` only once your
+# 1Click JWT has confidential access enabled (invite-only via the Partner Portal).
+# When true, a Public/Private toggle appears in the swap form. Public by default.
+NEXT_PUBLIC_CONFIDENTIAL_ENABLED=

--- a/near-intents/README.md
+++ b/near-intents/README.md
@@ -25,6 +25,7 @@ pnpx gitpick openfort-xyz/recipes-hub/tree/main/near-intents openfort-near-inten
 1. (Optional) Request a JWT at [partners.near-intents.org](https://partners.near-intents.org)
 2. Without a JWT the public endpoints work but apply a 0.2% fee and lower rate limits
 3. The JWT is read server-side only — it is never exposed to the browser
+4. (Optional) For **confidential swaps**, ask the NEAR team to enable Confidential Intents on your JWT — it's invite-only. Confidential quotes require an authenticated JWT; the public endpoint rejects them.
 
 ## 3. Configure Environment
 
@@ -41,7 +42,8 @@ NEXT_PUBLIC_OPENFORT_FEE_SPONSORSHIP_ID=pol_...     # Optional
 NEXT_PUBLIC_OPENFORT_DEFAULT_CHAIN_ID=8453          # Base
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=...            # Optional, enables wallet sign-in
 
-ONECLICK_JWT=...                                    # Optional, server-side only
+ONECLICK_JWT=...                                    # Optional, server-side only (required for confidential swaps)
+NEXT_PUBLIC_CONFIDENTIAL_ENABLED=true               # Optional, shows the Public/Private toggle
 ```
 
 Sign-in is restricted to **email** and **external wallet**. The wallet option only
@@ -64,11 +66,32 @@ pnpm dev
 2. **Deposit** — the Openfort wallet signs one transfer of the input asset to the deposit address (native send or ERC-20 `transfer`), switching chains first if needed.
 3. **Track** — `GET /api/status` polls `/v0/status` until the swap reaches `SUCCESS`, `REFUNDED`, or `FAILED`, with origin/destination explorer links.
 
+### Confidential swaps
+
+Set `NEXT_PUBLIC_CONFIDENTIAL_ENABLED=true` to show a **Public / Private** toggle
+in the swap form. Choosing *Private* adds one field to the quote request —
+`confidentiality: "basic"` — which routes the swap through [NEAR Confidential
+Intents](https://www.near.org/blog/confidential-intents) so the trade isn't
+broadcast on the public chain.
+
+This is the "foreign-to-foreign" confidential path, so nothing else changes: the
+deposit is still a normal `ORIGIN_CHAIN` → `DESTINATION_CHAIN` transfer signed by
+the Openfort wallet — no signed intents, no NEAR account. The `confidentiality`
+value is added server-side in `oneclick-server.ts` and threaded from the toggle
+through `useSwapController`.
+
+Two requirements: confidential quotes **require an authenticated JWT** (the public
+endpoint returns `401`), and access is **invite-only** — until your integration is
+enabled the API returns an invite-only message. The recipe maps that error to a
+clear prompt to request access or switch back to a public swap. The API also
+accepts `confidentiality: "advanced"` for a higher privacy tier.
+
 ## Features
 
 - **Cross-chain swaps** across Ethereum, Base, Arbitrum, Optimism, Polygon, and Avalanche
 - **Openfort embedded wallets** with email/social authentication
 - **Single-deposit UX** — solvers handle routing and settlement; no NEAR keys needed
+- **Confidential swaps** (optional) — a Public/Private toggle routes trades through NEAR Confidential Intents so they aren't broadcast publicly
 - **Gas sponsorship** with Openfort policies (optional)
 - **Live status tracking** with explorer links — the 1Click status response's
   `explorerUrl` is only trusted when absolute; otherwise links fall back to a

--- a/near-intents/src/features/near-intents/components/QuoteDisplay.tsx
+++ b/near-intents/src/features/near-intents/components/QuoteDisplay.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { formatUnits } from "viem";
-import { ArrowDown } from "lucide-react";
+import { ArrowDown, Lock } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { chainLabel } from "@/features/near-intents/constants";
-import type { QuoteResponse, SwapAsset } from "@/features/near-intents/types";
+import type {
+  Confidentiality,
+  QuoteResponse,
+  SwapAsset,
+} from "@/features/near-intents/types";
 import AssetIcon from "./AssetIcon";
 
 interface QuoteDisplayProps {
@@ -12,6 +16,7 @@ interface QuoteDisplayProps {
   fromAsset: SwapAsset;
   toAsset: SwapAsset;
   recipient: string;
+  confidentiality: Confidentiality;
 }
 
 const truncate = (value: string): string =>
@@ -30,13 +35,22 @@ export default function QuoteDisplay({
   fromAsset,
   toAsset,
   recipient,
+  confidentiality,
 }: QuoteDisplayProps) {
   const { quote: q } = quote;
   const minReceived = formatUnits(BigInt(q.minAmountOut), toAsset.decimals);
+  const isPrivate = confidentiality !== "public";
 
   return (
     <Card className="w-full max-w-md">
       <CardContent className="space-y-4 p-6">
+        {isPrivate && (
+          <div className="flex items-center gap-2 rounded-xl border border-violet-200 bg-violet-50 px-3 py-2 text-sm font-medium text-violet-700 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-300">
+            <Lock className="h-4 w-4" />
+            Private swap — routed through NEAR Confidential Intents
+          </div>
+        )}
+
         <Leg
           label="You send"
           asset={fromAsset}

--- a/near-intents/src/features/near-intents/components/SwapFlow.tsx
+++ b/near-intents/src/features/near-intents/components/SwapFlow.tsx
@@ -58,6 +58,7 @@ export default function SwapFlow() {
                 toAsset={state.toAsset}
                 amount={state.amount}
                 recipient={state.recipient}
+                confidentiality={state.confidentiality}
                 liveQuote={state.liveQuote}
                 estimateError={state.estimateError}
                 isLoadingEstimate={state.isLoadingEstimate}
@@ -66,6 +67,7 @@ export default function SwapFlow() {
                 onToAssetChange={actions.setToAsset}
                 onAmountChange={actions.setAmount}
                 onRecipientChange={actions.setRecipient}
+                onConfidentialityChange={actions.setConfidentiality}
                 onFlip={actions.flipAssets}
               />
             )}
@@ -79,6 +81,7 @@ export default function SwapFlow() {
                   fromAsset={state.fromAsset}
                   toAsset={state.toAsset}
                   recipient={state.recipient}
+                  confidentiality={state.confidentiality}
                 />
               )}
 

--- a/near-intents/src/features/near-intents/components/SwapForm.tsx
+++ b/near-intents/src/features/near-intents/components/SwapForm.tsx
@@ -1,14 +1,20 @@
 "use client";
 
 import { useState } from "react";
-import { ArrowDown, ChevronDown } from "lucide-react";
+import { ArrowDown, ChevronDown, Eye, Lock } from "lucide-react";
 import { erc20Abi, formatUnits } from "viem";
 import { useBalance, useReadContract } from "wagmi";
 import {
   chainLabel,
+  CONFIDENTIAL_SWAPS_ENABLED,
   isOriginBlockchain,
+  PRIVATE_CONFIDENTIALITY,
 } from "@/features/near-intents/constants";
-import type { Quote, SwapAsset } from "@/features/near-intents/types";
+import type {
+  Confidentiality,
+  Quote,
+  SwapAsset,
+} from "@/features/near-intents/types";
 import AssetIcon from "./AssetIcon";
 import AssetPicker from "./AssetPicker";
 import FundWallet from "./FundWallet";
@@ -20,6 +26,7 @@ interface SwapFormProps {
   toAsset: SwapAsset | null;
   amount: string;
   recipient: string;
+  confidentiality: Confidentiality;
   liveQuote: Quote | null;
   estimateError: string | null;
   isLoadingEstimate: boolean;
@@ -28,6 +35,7 @@ interface SwapFormProps {
   onToAssetChange: (asset: SwapAsset) => void;
   onAmountChange: (amount: string) => void;
   onRecipientChange: (recipient: string) => void;
+  onConfidentialityChange: (value: Confidentiality) => void;
   onFlip: () => void;
 }
 
@@ -38,6 +46,7 @@ export default function SwapForm({
   toAsset,
   amount,
   recipient,
+  confidentiality,
   liveQuote,
   estimateError,
   isLoadingEstimate,
@@ -46,6 +55,7 @@ export default function SwapForm({
   onToAssetChange,
   onAmountChange,
   onRecipientChange,
+  onConfidentialityChange,
   onFlip,
 }: SwapFormProps) {
   const [pickerField, setPickerField] = useState<"from" | "to" | null>(null);
@@ -68,6 +78,13 @@ export default function SwapForm({
           <h2 className="text-lg font-semibold">Swap</h2>
           {walletAddress && <FundWallet walletAddress={walletAddress} />}
         </div>
+
+        {CONFIDENTIAL_SWAPS_ENABLED && (
+          <PrivacyToggle
+            confidentiality={confidentiality}
+            onChange={onConfidentialityChange}
+          />
+        )}
 
         <AssetField
           label="You send"
@@ -171,6 +188,72 @@ export default function SwapForm({
         onSelect={handleSelect}
       />
     </div>
+  );
+}
+
+// Public / Private segmented control. "Private" routes the swap through NEAR
+// Confidential Intents (confidentiality: "basic") so the trade isn't broadcast
+// publicly; "Public" is a normal on-chain swap.
+function PrivacyToggle({
+  confidentiality,
+  onChange,
+}: {
+  confidentiality: Confidentiality;
+  onChange: (value: Confidentiality) => void;
+}) {
+  const isPrivate = confidentiality !== "public";
+
+  return (
+    <div className="mb-4">
+      <div className="grid grid-cols-2 gap-1 rounded-xl border border-border bg-muted/40 p-1">
+        <PrivacyOption
+          active={!isPrivate}
+          onClick={() => onChange("public")}
+          icon={<Eye className="h-4 w-4" />}
+          label="Public"
+        />
+        <PrivacyOption
+          active={isPrivate}
+          onClick={() => onChange(PRIVATE_CONFIDENTIALITY)}
+          icon={<Lock className="h-4 w-4" />}
+          label="Private"
+        />
+      </div>
+      {isPrivate && (
+        <p className="mt-1.5 text-xs text-muted-foreground">
+          Routed through NEAR Confidential Intents — the swap isn&apos;t broadcast
+          publicly. Deposit still comes from your Openfort wallet.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PrivacyOption({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`flex items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground"
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
   );
 }
 

--- a/near-intents/src/features/near-intents/constants/index.ts
+++ b/near-intents/src/features/near-intents/constants/index.ts
@@ -83,3 +83,13 @@ export const QUOTE_DEADLINE_MINUTES = 30;
 export const STATUS_POLL_INTERVAL_MS = 4000;
 
 export const TERMINAL_STATUSES = ["SUCCESS", "REFUNDED", "FAILED"] as const;
+
+// Confidential swaps (NEAR Confidential Intents) are invite-only and require an
+// authenticated 1Click integration. The browser can't see the server-side JWT,
+// so this public flag gates whether the privacy toggle is shown at all. Set it
+// only once your 1Click JWT has confidential access enabled.
+export const CONFIDENTIAL_SWAPS_ENABLED =
+  process.env.NEXT_PUBLIC_CONFIDENTIAL_ENABLED === "true";
+
+// The confidentiality level applied when the user turns on the privacy toggle.
+export const PRIVATE_CONFIDENTIALITY = "basic" as const;

--- a/near-intents/src/features/near-intents/hooks/use-swap-controller.ts
+++ b/near-intents/src/features/near-intents/hooks/use-swap-controller.ts
@@ -23,6 +23,7 @@ import {
   pickDefaultPair,
 } from "@/features/near-intents/utils/asset-helpers";
 import type {
+  Confidentiality,
   ExecutionStatusResponse,
   Quote,
   QuoteResponse,
@@ -37,6 +38,7 @@ interface SwapState {
   toAsset: SwapAsset | null;
   amount: string;
   recipient: string;
+  confidentiality: Confidentiality;
   liveQuote: Quote | null;
   estimateError: string | null;
   isLoadingEstimate: boolean;
@@ -55,6 +57,7 @@ const INITIAL_STATE: SwapState = {
   toAsset: null,
   amount: DEFAULT_SWAP_AMOUNT,
   recipient: "",
+  confidentiality: "public",
   liveQuote: null,
   estimateError: null,
   isLoadingEstimate: false,
@@ -74,6 +77,11 @@ const isTerminal = (status: SwapStatus | null): boolean =>
 // Turn raw 1Click errors into actionable copy. The "amount too low" error
 // reports the minimum in origin base units; convert it to a human amount.
 const humanizeQuoteError = (message: string, fromAsset: SwapAsset): string => {
+  // Confidential swaps are invite-only and require a confidential-enabled JWT.
+  // Surface a clear next step instead of a raw 401 / invite-only message.
+  if (/confidential|invite/i.test(message) && /auth|invite|401/i.test(message)) {
+    return "Confidential swaps aren't enabled for this 1Click key yet. Request access at partners.near-intents.org, or switch off private mode to swap publicly.";
+  }
   const match = message.match(/at least (\d+)/);
   if (match) {
     const min = formatUnits(BigInt(match[1]), fromAsset.decimals);
@@ -95,6 +103,7 @@ export interface SwapController {
     setToAsset: (asset: SwapAsset | null) => void;
     setAmount: (amount: string) => void;
     setRecipient: (recipient: string) => void;
+    setConfidentiality: (value: Confidentiality) => void;
     flipAssets: () => void;
     getQuote: () => Promise<void>;
     confirmDeposit: () => Promise<void>;
@@ -119,7 +128,8 @@ export const useSwapController = (): SwapController => {
   const [isLoadingAssets, setIsLoadingAssets] = useState(true);
   const [state, setState] = useState<SwapState>(INITIAL_STATE);
 
-  const { fromAsset, toAsset, amount, step, quote, recipient } = state;
+  const { fromAsset, toAsset, amount, step, quote, recipient, confidentiality } =
+    state;
 
   useEffect(() => {
     let cancelled = false;
@@ -227,6 +237,7 @@ export const useSwapController = (): SwapController => {
           amount: amountBase,
           recipient: effectiveRecipient,
           refundTo: walletAddress,
+          confidentiality,
           dry: true,
         });
         setState((prev) => ({
@@ -251,7 +262,7 @@ export const useSwapController = (): SwapController => {
     return () => {
       window.clearTimeout(timeout);
     };
-  }, [step, fromAsset, toAsset, amount, walletAddress, recipient]);
+  }, [step, fromAsset, toAsset, amount, walletAddress, recipient, confidentiality]);
 
   const handleGetQuote = useCallback(async () => {
     if (!fromAsset || !toAsset || !amount || !walletAddress || !isReady) {
@@ -290,6 +301,7 @@ export const useSwapController = (): SwapController => {
         amount: amountBase,
         recipient,
         refundTo: walletAddress,
+        confidentiality,
         dry: false,
       });
       if (!result.quote.depositAddress) {
@@ -311,7 +323,7 @@ export const useSwapController = (): SwapController => {
             : "Failed to fetch quote",
       }));
     }
-  }, [fromAsset, toAsset, amount, walletAddress, isReady, recipient]);
+  }, [fromAsset, toAsset, amount, walletAddress, isReady, recipient, confidentiality]);
 
   const handleConfirmDeposit = useCallback(async () => {
     if (!quote || !fromAsset || !walletAddress || !fromAsset.chainId) {
@@ -431,6 +443,8 @@ export const useSwapController = (): SwapController => {
         setState((prev) => ({ ...prev, amount: value })),
       setRecipient: (value: string) =>
         setState((prev) => ({ ...prev, recipient: value })),
+      setConfidentiality: (value: Confidentiality) =>
+        setState((prev) => ({ ...prev, confidentiality: value })),
       flipAssets: () =>
         setState((prev) => {
           // Origin must stay EVM, so only flip when the destination is an
@@ -459,6 +473,7 @@ export const useSwapController = (): SwapController => {
           fromAsset: prev.fromAsset,
           toAsset: prev.toAsset,
           recipient: prev.recipient,
+          confidentiality: prev.confidentiality,
         })),
     }),
     [handleGetQuote, handleConfirmDeposit]

--- a/near-intents/src/features/near-intents/services/oneclick-server.ts
+++ b/near-intents/src/features/near-intents/services/oneclick-server.ts
@@ -63,6 +63,10 @@ export const requestQuote = async (
     refundType: "ORIGIN_CHAIN",
     recipientType: "DESTINATION_CHAIN",
     depositMode: "SIMPLE",
+    // Foreign-to-foreign confidential swaps keep the standard ORIGIN_CHAIN
+    // deposit flow — only the `confidentiality` level changes. `basic` and
+    // `advanced` require an authenticated, confidential-enabled JWT.
+    confidentiality: params.confidentiality ?? "public",
     originAsset: params.originAsset,
     destinationAsset: params.destinationAsset,
     amount: params.amount,

--- a/near-intents/src/features/near-intents/types.ts
+++ b/near-intents/src/features/near-intents/types.ts
@@ -84,6 +84,14 @@ export interface ExecutionStatusResponse {
   swapDetails: SwapDetails;
 }
 
+/**
+ * Privacy level for a swap. `public` is a normal on-chain swap. `basic` and
+ * `advanced` route the swap through NEAR's Confidential Intents so the trade is
+ * not broadcast publicly. Confidential levels require an authenticated (JWT)
+ * 1Click integration that has been granted access — see the README.
+ */
+export type Confidentiality = "public" | "basic" | "advanced";
+
 /** Client-supplied portion of a quote request; the server fills the rest. */
 export interface QuoteRequestParams {
   originAsset: string;
@@ -92,4 +100,6 @@ export interface QuoteRequestParams {
   recipient: string;
   refundTo: string;
   dry: boolean;
+  /** Defaults to `public` when omitted. */
+  confidentiality?: Confidentiality;
 }


### PR DESCRIPTION
Adds an optional **confidential swap** mode to the NEAR Intents recipe.

## What this does
A **Public / Private** toggle in the swap form. Choosing *Private* adds one field to the 1Click quote — `confidentiality: "basic"` — which routes the swap through [NEAR Confidential Intents](https://www.near.org/blog/confidential-intents) so the trade isn't broadcast on the public chain.

This is the "foreign-to-foreign" confidential path, so the swap flow is otherwise unchanged: the deposit is still a normal `ORIGIN_CHAIN` → `DESTINATION_CHAIN` transfer signed by the Openfort wallet — no signed intents, no NEAR account.

## Changes
- `services/oneclick-server.ts` — add `confidentiality` to the quote body (defaults to `"public"`)
- `hooks/use-swap-controller.ts` — thread `confidentiality` into the live estimate and the real quote; map the confidential auth / invite-only error to actionable copy
- `components/SwapForm.tsx` — Public/Private toggle, shown only when `NEXT_PUBLIC_CONFIDENTIAL_ENABLED=true` (the browser can't see the server-side JWT)
- `components/QuoteDisplay.tsx` — "Private swap" badge on the confirmed quote
- `types.ts` / `constants/index.ts` — `Confidentiality` type + feature flag
- `README.md` — document the toggle, the flag, and the requirements
- `.env.example` — now committed (the README's `cp .env.example .env.local` referenced a file that was never tracked) and documents the new flag

## Requirements
Confidential quotes require an **authenticated JWT** (the public 1Click endpoint returns `401`) and access is **invite-only** via [partners.near-intents.org](https://partners.near-intents.org). Default behavior is unchanged — public swaps work without any of this.

## Verification
Validated the `confidentiality` field against the live 1Click API (`public`/`basic`/`advanced` accepted; `basic` returns `401` without auth). `tsc --noEmit`, `next lint`, and `next build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)