### PR TITLE
[telegram-bot] Telegram bot with a server-side wallet per user

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 ## Project overview
-- Collection of Openfort integration samples (`7702`, `aave`, `agent-permissions`, `hyperliquid`, `lifi`, `morpho`, `mpp`, `near-intents`, `usdc`, `vaults-fyi`, `x402`).
+- Collection of Openfort integration samples (`7702`, `aave`, `agent-permissions`, `hyperliquid`, `lifi`, `morpho`, `mpp`, `near-intents`, `telegram-bot`, `usdc`, `vaults-fyi`, `x402`).
 - Each subdirectory has its own `AGENTS.md` with detailed setup instructions; start at the sample you are modifying.
 
 ## Setup commands

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains comprehensive samples demonstrating how to integrate Op
 | **[Backend permissions](./agent-permissions/)**                               | Setup a wallet permissions that automatically DCA on Morpho completely non-custodial.                                   | `pnpx gitpick openfort-xyz/recipes-hub/tree/main/morpho openfort-morpho && cd openfort-morpho`                |
 | **[7702 delegation](./7702/)** | Openfort EIP-7702 authorization recipe with gas sponsorship.                                                          | `pnpx gitpick openfort-xyz/recipes-hub/tree/main/7702 openfort-7702 && cd openfort-7702`                      |
 | **[x402 Agent](./x402/)**                                    | Embedded wallet and Bakcned wallet x402 payment integration. Demonstrates content paywalls with USDC payments using gas sposnsorship and facilitator.  | `pnpx gitpick openfort-xyz/recipes-hub/tree/main/x402 openfort-x402 && cd openfort-x402`                      |
+| **[Telegram wallet bot](./telegram-bot/)**                  | Telegram bot where every user gets their own server-side wallet, keyed by Telegram user ID. Chat commands create wallets, check balances, and send USDC with sponsored gas on Base Sepolia. | `pnpx gitpick openfort-xyz/recipes-hub/tree/main/telegram-bot openfort-telegram-bot && cd openfort-telegram-bot` |
 | **[Trade on Lighter](./lighter/)**                            | Mainnet perps trading on the Lighter zk L2 DEX. Embedded wallet authorizes account registration and deposits; a backend holds the Lighter API key and signs orders via a vendored WASM build of lighter-go. | `pnpx gitpick openfort-xyz/recipes-hub/tree/main/lighter openfort-lighter && cd openfort-lighter`             |
 
 ## Getting Started
@@ -33,5 +34,6 @@ Each sample is completely self-contained with its own setup instructions, enviro
 | **USDC**                | React Native | -          | Ethereum Sepolia  | `@openfort/react-native`, `expo`                     |
 | **7702** | Next.js 15   | -          | Ethereum Sepolia  | `@openfort/react`, `viem`, `wagmi` |
 | **x402**                | React + Vite | Node.js    | Base/Base-Sepolia | `@openfort/react`, `wagmi`, `viem`                   |
+| **Telegram bot**        | -            | Node.js    | Base Sepolia      | `grammy`, `@openfort/openfort-node`, `viem`          |
 | **Lighter**             | React Native | Node.js    | Ethereum mainnet  | `@openfort/react-native`, vendored `lighter-go` WASM |
 

--- a/telegram-bot/.env.example
+++ b/telegram-bot/.env.example
@@ -1,0 +1,11 @@
+# Openfort project secret key (dashboard.openfort.io → API keys)
+OPENFORT_SECRET_KEY=sk_test_...
+
+# Wallet secret for backend wallets (dashboard → Backend wallets → Setup)
+OPENFORT_WALLET_SECRET=...
+
+# Gas sponsorship policy for Base Sepolia (dashboard → Gas sponsorship)
+OPENFORT_GAS_POLICY_ID=pol_...
+
+# Telegram bot token from @BotFather (/newbot). Optional: `pnpm demo` runs without it.
+TELEGRAM_BOT_TOKEN=

--- a/telegram-bot/.gitignore
+++ b/telegram-bot/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+data/

--- a/telegram-bot/AGENTS.md
+++ b/telegram-bot/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md — telegram-bot
+
+## Overview
+- Telegram bot where each Telegram user gets an Openfort backend wallet (custodial, server-signed), keyed by Telegram user ID.
+- Base Sepolia (84532), USDC `0x036CbD53842c5426634e7929541eC2318f3dCF7e`, gas sponsored via `OPENFORT_GAS_POLICY_ID`.
+- No frontend. `src/commands.ts` holds pure handlers; `src/bot.ts` (grammY long-polling) and `src/demo.ts` (offline harness) both consume them.
+
+## Setup commands
+- `pnpm install`
+- `cp .env.example .env` and fill `OPENFORT_SECRET_KEY`, `OPENFORT_WALLET_SECRET`, `OPENFORT_GAS_POLICY_ID`. `TELEGRAM_BOT_TOKEN` only needed for `pnpm start`.
+- `pnpm demo` — runs /start → /balance → /send end-to-end with a fake Telegram user (no token needed). Funds the demo wallet from the treasury backend wallet if it holds ≥0.05 USDC.
+- `pnpm start` — live bot via long polling.
+
+## Testing instructions
+- `pnpm type-check` and `pnpm lint` must pass.
+- `pnpm demo` is the E2E check — it submits real sponsored transactions on Base Sepolia and prints explorer links.
+
+## Gotchas
+- Wallet secret is project-scoped: `OPENFORT_WALLET_SECRET` must belong to the same project as `OPENFORT_SECRET_KEY` or every signing call 401s.
+- `openfort.accounts.evm.backend.get({ address })` requires the EIP-55 checksummed address, not lowercase.
+- `sendTransaction` auto-upgrades the EOA to a 7702 delegated account on first use; the gas policy needs an `account_functions` "All functions" rule to actually sponsor.
+- The wallet mapping lives in `data/wallets.json` (gitignored). Delete it to start fresh — old accounts remain in the Openfort project.

--- a/telegram-bot/README.md
+++ b/telegram-bot/README.md
@@ -1,0 +1,37 @@
+# Telegram wallet bot
+
+A Telegram bot where every user gets their own on-chain wallet, created and operated server-side with [Openfort backend wallets](https://www.openfort.io/docs/products/server). Users chat commands; the bot signs and submits transactions on their behalf — no app install, no seed phrase, no gas.
+
+- `/start` — creates a wallet for the Telegram user (mapped by their Telegram user ID)
+- `/balance` — ETH + USDC balance on Base Sepolia
+- `/send <address> <amount>` — sends USDC, gas sponsored by your project policy
+
+## How it works
+
+Each Telegram user ID maps to one Openfort backend wallet (`data/wallets.json` here; use your real database in production). Openfort holds the encrypted keys; your server authorizes every signature with the wallet secret. Gas is sponsored through a policy, so wallets work with zero ETH.
+
+```
+Telegram user ──/send──▶ bot (grammY) ──▶ Openfort backend wallet ──▶ Base Sepolia
+                                  │
+                          telegram_user_id → account_id
+```
+
+The command handlers in `src/commands.ts` are plain functions — `src/bot.ts` wires them to Telegram, `src/demo.ts` drives them directly so you can verify the whole flow without a bot token.
+
+## Setup
+
+1. `pnpm install`
+2. `cp .env.example .env` and fill in:
+   - `OPENFORT_SECRET_KEY` — dashboard → API keys
+   - `OPENFORT_WALLET_SECRET` — dashboard → Backend wallets → Setup
+   - `OPENFORT_GAS_POLICY_ID` — a Base Sepolia gas sponsorship policy
+3. Try the flow without Telegram: `pnpm demo`
+4. Go live: message [@BotFather](https://t.me/botfather), run `/newbot`, put the token in `TELEGRAM_BOT_TOKEN`, then `pnpm start` and message your bot.
+
+To fund a wallet with test USDC, use [Circle's faucet](https://faucet.circle.com) (Base Sepolia).
+
+## Production notes
+
+- Swap `data/wallets.json` for your database — store only the account `id` and address, never keys.
+- Add [signing policies](https://www.openfort.io/docs/configuration/policies) to cap what each wallet can do (contracts, methods, spend limits).
+- If a user wants to leave with their key, backend wallets support [export](https://www.openfort.io/docs/products/server/accounts#exporting-accounts).

--- a/telegram-bot/biome.json
+++ b/telegram-bot/biome.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "asNeeded"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/telegram-bot/package.json
+++ b/telegram-bot/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "openfort-telegram-bot",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/bot.ts",
+    "demo": "tsx src/demo.ts",
+    "lint": "biome check src",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@openfort/openfort-node": "0.10.8",
+    "dotenv": "17.2.3",
+    "grammy": "1.45.1",
+    "viem": "2.55.5"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.4",
+    "@types/node": "22.20.1",
+    "tsx": "4.23.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/telegram-bot/src/bot.ts
+++ b/telegram-bot/src/bot.ts
@@ -1,0 +1,36 @@
+import { Bot } from 'grammy'
+import { handleBalance, handleSend, handleStart } from './commands.js'
+import { config } from './config.js'
+
+if (!config.telegramBotToken) {
+  throw new Error(
+    'Missing TELEGRAM_BOT_TOKEN. Create a bot with @BotFather (/newbot) and put the token in .env. ' +
+      'To try the wallet flow without Telegram, run `pnpm demo` instead.',
+  )
+}
+
+const bot = new Bot(config.telegramBotToken)
+
+bot.command('start', async (ctx) => {
+  if (!ctx.from) return
+  await ctx.reply(await handleStart(ctx.from.id), { link_preview_options: { is_disabled: true } })
+})
+
+bot.command('balance', async (ctx) => {
+  if (!ctx.from) return
+  await ctx.reply(await handleBalance(ctx.from.id))
+})
+
+bot.command('send', async (ctx) => {
+  if (!ctx.from) return
+  await ctx.reply(await handleSend(ctx.from.id, ctx.match), {
+    link_preview_options: { is_disabled: true },
+  })
+})
+
+bot.catch((err) => {
+  console.error('Bot error:', err.error)
+})
+
+console.log('Bot running — message it on Telegram. Ctrl+C to stop.')
+bot.start()

--- a/telegram-bot/src/commands.ts
+++ b/telegram-bot/src/commands.ts
@@ -1,0 +1,46 @@
+import { isAddress } from 'viem'
+import { EXPLORER_URL } from './config.js'
+import { getBalances, getOrCreateWallet, getWalletAddress, sendUsdc } from './wallets.js'
+
+export async function handleStart(telegramUserId: number): Promise<string> {
+  const existing = getWalletAddress(telegramUserId)
+  const account = await getOrCreateWallet(telegramUserId)
+  const intro = existing
+    ? 'Welcome back! Your wallet is ready.'
+    : 'Wallet created! It lives on Base Sepolia and all gas is sponsored — you never need ETH.'
+  return [
+    intro,
+    '',
+    `Address: ${account.address}`,
+    `${EXPLORER_URL}/address/${account.address}`,
+    '',
+    'Commands:',
+    '/balance — check your ETH and USDC balance',
+    '/send <address> <amount> — send USDC, gas-free',
+  ].join('\n')
+}
+
+export async function handleBalance(telegramUserId: number): Promise<string> {
+  const address = getWalletAddress(telegramUserId)
+  if (!address) return 'No wallet yet — run /start first.'
+  const { eth, usdc } = await getBalances(address as `0x${string}`)
+  return `Balance for ${address}\n\nETH: ${eth}\nUSDC: ${usdc}`
+}
+
+export async function handleSend(telegramUserId: number, args: string): Promise<string> {
+  const address = getWalletAddress(telegramUserId)
+  if (!address) return 'No wallet yet — run /start first.'
+
+  const [to, amount] = args.trim().split(/\s+/)
+  if (!to || !amount || !isAddress(to) || Number.isNaN(Number(amount)) || Number(amount) < 0) {
+    return 'Usage: /send <0x-address> <amount>\nExample: /send 0x1486…7ACB 0.5'
+  }
+
+  const { usdc } = await getBalances(address as `0x${string}`)
+  if (Number(amount) > Number(usdc)) {
+    return `Not enough USDC — you have ${usdc}, tried to send ${amount}.`
+  }
+
+  const hash = await sendUsdc(telegramUserId, to, amount)
+  return `Sent ${amount} USDC to ${to}\n\n${EXPLORER_URL}/tx/${hash}`
+}

--- a/telegram-bot/src/config.ts
+++ b/telegram-bot/src/config.ts
@@ -1,0 +1,22 @@
+import 'dotenv/config'
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing environment variable ${name}. Copy .env.example to .env and fill it in (see README).`)
+  }
+  return value
+}
+
+export const config = {
+  openfortSecretKey: required('OPENFORT_SECRET_KEY'),
+  openfortWalletSecret: required('OPENFORT_WALLET_SECRET'),
+  gasPolicyId: required('OPENFORT_GAS_POLICY_ID'),
+  // biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket access
+  telegramBotToken: process.env['TELEGRAM_BOT_TOKEN'],
+}
+
+export const CHAIN_ID = 84532 // Base Sepolia
+export const USDC_ADDRESS = '0x036CbD53842c5426634e7929541eC2318f3dCF7e' as const
+export const USDC_DECIMALS = 6
+export const EXPLORER_URL = 'https://sepolia.basescan.org'

--- a/telegram-bot/src/demo.ts
+++ b/telegram-bot/src/demo.ts
@@ -1,0 +1,47 @@
+// Drives the exact same command handlers the Telegram bot uses, with a fake
+// Telegram user — verifies the full Openfort flow end-to-end without a bot token.
+import { handleBalance, handleSend, handleStart } from './commands.js'
+import { openfort } from './openfort.js'
+import { getBalances, getWalletAddress } from './wallets.js'
+
+const DEMO_TELEGRAM_USER_ID = 777_000_111
+const TREASURY_ADDRESS = '0xB7fd0ac229f66a64623Df7DBfD42B955AD5673f9' as const
+
+function say(label: string, reply: string) {
+  console.log(`\n── ${label} ${'─'.repeat(Math.max(0, 60 - label.length))}\n${reply}`)
+}
+
+say('/start', await handleStart(DEMO_TELEGRAM_USER_ID))
+say('/balance', await handleBalance(DEMO_TELEGRAM_USER_ID))
+
+// Fund the demo wallet from the project treasury so /send moves real USDC.
+const demoAddress = getWalletAddress(DEMO_TELEGRAM_USER_ID) as `0x${string}`
+const demoBalance = await getBalances(demoAddress)
+if (Number(demoBalance.usdc) < 0.02) {
+  const treasury = await getBalances(TREASURY_ADDRESS)
+  if (Number(treasury.usdc) >= 0.05) {
+    console.log(`\nFunding demo wallet with 0.05 USDC from treasury ${TREASURY_ADDRESS}…`)
+    const treasuryAccount = await openfort.accounts.evm.backend.get({ address: TREASURY_ADDRESS })
+    const { sendUsdcFrom } = await import('./treasury.js')
+    const hash = await sendUsdcFrom(treasuryAccount, demoAddress, '0.05')
+    console.log(`Funded: https://sepolia.basescan.org/tx/${hash}`)
+  } else {
+    console.log(
+      `\nTreasury has ${treasury.usdc} USDC — not enough to fund the demo. ` +
+        'The /send step below will fail on balance; top up the treasury with Base Sepolia USDC from https://faucet.circle.com.',
+    )
+  }
+}
+
+const { usdc } = await getBalances(demoAddress)
+const amount = Number(usdc) >= 0.02 ? '0.02' : '0'
+if (amount === '0') {
+  console.log(
+    '\nNo test USDC available — sending a 0-USDC transfer to prove the sponsored pipeline. ' +
+      'Top up any wallet above at https://faucet.circle.com for a real amount.',
+  )
+}
+say(`/send ${amount} USDC`, await handleSend(DEMO_TELEGRAM_USER_ID, `${TREASURY_ADDRESS} ${amount}`))
+say('/balance (after send)', await handleBalance(DEMO_TELEGRAM_USER_ID))
+
+console.log('\nDemo complete — same handlers the live bot uses, verified on Base Sepolia.')

--- a/telegram-bot/src/openfort.ts
+++ b/telegram-bot/src/openfort.ts
@@ -1,0 +1,6 @@
+import Openfort from '@openfort/openfort-node'
+import { config } from './config.js'
+
+export const openfort = new Openfort(config.openfortSecretKey, {
+  walletSecret: config.openfortWalletSecret,
+})

--- a/telegram-bot/src/store.ts
+++ b/telegram-bot/src/store.ts
@@ -1,0 +1,25 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+export interface StoredWallet {
+  accountId: string
+  address: string
+}
+
+const STORE_PATH = join(process.cwd(), 'data', 'wallets.json')
+
+function load(): Record<string, StoredWallet> {
+  if (!existsSync(STORE_PATH)) return {}
+  return JSON.parse(readFileSync(STORE_PATH, 'utf-8'))
+}
+
+export function getStoredWallet(telegramUserId: number): StoredWallet | undefined {
+  return load()[String(telegramUserId)]
+}
+
+export function saveStoredWallet(telegramUserId: number, wallet: StoredWallet): void {
+  const wallets = load()
+  wallets[String(telegramUserId)] = wallet
+  mkdirSync(dirname(STORE_PATH), { recursive: true })
+  writeFileSync(STORE_PATH, `${JSON.stringify(wallets, null, 2)}\n`, 'utf-8')
+}

--- a/telegram-bot/src/treasury.ts
+++ b/telegram-bot/src/treasury.ts
@@ -1,0 +1,24 @@
+import { encodeFunctionData, erc20Abi, parseUnits } from 'viem'
+import { CHAIN_ID, config, USDC_ADDRESS, USDC_DECIMALS } from './config.js'
+import { openfort } from './openfort.js'
+
+type BackendAccount = Awaited<ReturnType<typeof openfort.accounts.evm.backend.create>>
+
+export async function sendUsdcFrom(account: BackendAccount, to: `0x${string}`, amount: string): Promise<string> {
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [to, parseUnits(amount, USDC_DECIMALS)],
+  })
+  const result = await openfort.accounts.evm.backend.sendTransaction({
+    account,
+    chainId: CHAIN_ID,
+    interactions: [{ to: USDC_ADDRESS, data }],
+    policy: config.gasPolicyId,
+  })
+  const hash = result.response?.transactionHash
+  if (!hash) {
+    throw new Error(`Treasury transfer not submitted: ${JSON.stringify(result.response ?? result)}`)
+  }
+  return hash
+}

--- a/telegram-bot/src/wallets.ts
+++ b/telegram-bot/src/wallets.ts
@@ -1,0 +1,61 @@
+import { createPublicClient, encodeFunctionData, erc20Abi, formatEther, formatUnits, http, parseUnits } from 'viem'
+import { baseSepolia } from 'viem/chains'
+import { CHAIN_ID, config, USDC_ADDRESS, USDC_DECIMALS } from './config.js'
+import { openfort } from './openfort.js'
+import { getStoredWallet, saveStoredWallet } from './store.js'
+
+const publicClient = createPublicClient({ chain: baseSepolia, transport: http() })
+
+type BackendAccount = Awaited<ReturnType<typeof openfort.accounts.evm.backend.create>>
+
+export async function getOrCreateWallet(telegramUserId: number): Promise<BackendAccount> {
+  const stored = getStoredWallet(telegramUserId)
+  if (stored) return openfort.accounts.evm.backend.get({ id: stored.accountId })
+
+  const account = await openfort.accounts.evm.backend.create()
+  saveStoredWallet(telegramUserId, { accountId: account.id, address: account.address })
+  return account
+}
+
+export function getWalletAddress(telegramUserId: number): string | undefined {
+  return getStoredWallet(telegramUserId)?.address
+}
+
+export async function getBalances(address: `0x${string}`) {
+  const [wei, usdcUnits] = await Promise.all([
+    publicClient.getBalance({ address }),
+    publicClient.readContract({
+      address: USDC_ADDRESS,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [address],
+    }),
+  ])
+  return {
+    eth: formatEther(wei),
+    usdc: formatUnits(usdcUnits, USDC_DECIMALS),
+    usdcUnits,
+  }
+}
+
+export async function sendUsdc(telegramUserId: number, to: `0x${string}`, amount: string): Promise<string> {
+  const account = await getOrCreateWallet(telegramUserId)
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [to, parseUnits(amount, USDC_DECIMALS)],
+  })
+
+  const result = await openfort.accounts.evm.backend.sendTransaction({
+    account,
+    chainId: CHAIN_ID,
+    interactions: [{ to: USDC_ADDRESS, data }],
+    policy: config.gasPolicyId,
+  })
+
+  const hash = result.response?.transactionHash
+  if (!hash) {
+    throw new Error(`Transaction was not submitted: ${JSON.stringify(result.response ?? result)}`)
+  }
+  return hash
+}

--- a/telegram-bot/tsconfig.json
+++ b/telegram-bot/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Openfort port of the Telegram-bot wallet pattern (the one Privy documents at docs.privy.io/recipes/telegram-bot): a bot where every Telegram user gets their own on-chain wallet, created and operated server-side with Openfort backend wallets.

- `/start` creates a backend wallet mapped to the Telegram user ID (`data/wallets.json` locally; your DB in production)
- `/balance` reads ETH + USDC on Base Sepolia via viem
- `/send <address> <amount>` sends USDC through `accounts.evm.backend.sendTransaction` with a gas sponsorship policy — wallets work with zero ETH

Handlers in `src/commands.ts` are plain functions consumed by both `src/bot.ts` (grammY long-polling) and `src/demo.ts`, an offline harness that runs the full flow without a Telegram token.

Verified end-to-end on Base Sepolia: sponsored transaction from a freshly created wallet holding 0 ETH — https://sepolia.basescan.org/tx/0x920a4c1da12a88c525ae9ec5ea8305ba4aa9d10cc78defd12eb287d4e18c0ab8 (status success, submitted by the sponsor relayer).

`pnpm type-check` and `pnpm lint` (Biome) pass. README + AGENTS registered in the root tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)