### PR TITLE
zama-confidential-yield: headless SDK v2, sponsored UserOperations, bottom tab bar

### DIFF
--- a/zama-confidential-yield/.env.example
+++ b/zama-confidential-yield/.env.example
@@ -9,10 +9,15 @@ VITE_NETWORK=sepolia
 VITE_OPENFORT_PUBLISHABLE_KEY=pk_test_...
 VITE_OPENFORT_SHIELD_KEY=...
 
-# Paymaster policy (pol_…) for the chosen network. The wallet is always an
-# EIP-7702 DELEGATED account; set this to route every tx as a sponsored userop.
-# Leave empty and the delegated wallet pays its own (test) ETH gas.
-VITE_OPENFORT_FEE_SPONSORSHIP_ID=pol_...
+# Paymaster policy (pol_…) for the chosen network. Set it and the wallet is an
+# EIP-7702 DELEGATED account with every tx sponsored; leave it empty and the same
+# EOA pays its own (test) ETH gas — fund it from a Sepolia faucet.
+#
+# Known Openfort-side issue: the FIRST write from an undelegated 7702 account
+# takes ~30s to build and Cloudflare cuts the request at 15s, so it fails with
+# "Transaction creation failed … Details: Network Error". Leave this empty to run
+# self-paid until that is fixed.
+VITE_OPENFORT_FEE_SPONSORSHIP_ID=
 
 # JSON-RPC for the chosen network — used by wagmi, the Openfort embedded provider
 # and the Zama SDK alike. Defaults to the chain's public RPC; use your own

--- a/zama-confidential-yield/.env.example
+++ b/zama-confidential-yield/.env.example
@@ -14,10 +14,9 @@ VITE_OPENFORT_SHIELD_KEY=...
 # Leave empty and the delegated wallet pays its own (test) ETH gas.
 VITE_OPENFORT_FEE_SPONSORSHIP_ID=pol_...
 
-# JSON-RPC for the chosen network (use your own Alchemy/Infura for anything real).
+# JSON-RPC for the chosen network — used by wagmi, the Openfort embedded provider
+# and the Zama SDK alike. Defaults to the chain's public RPC; use your own
+# Alchemy/Infura for anything real, the Zama relayer is flaky behind public nodes.
 #   sepolia : https://ethereum-sepolia-rpc.publicnode.com
 #   mainnet : https://ethereum-rpc.publicnode.com
 VITE_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
-
-# Optional — external wallet connectors in the Openfort modal.
-VITE_WALLET_CONNECT_PROJECT_ID=

--- a/zama-confidential-yield/.gitignore
+++ b/zama-confidential-yield/.gitignore
@@ -9,3 +9,7 @@ dist-ssr
 *.log
 .vite
 .gstack/
+
+# one-off local ops scripts (not part of the recipe)
+*.local.mjs
+relayer.key

--- a/zama-confidential-yield/README.md
+++ b/zama-confidential-yield/README.md
@@ -10,10 +10,18 @@ Set `VITE_OPENFORT_FEE_SPONSORSHIP_ID` and that same EOA is EIP-7702-delegated s
 Openfort **paymaster** sponsors every transaction; leave it empty and the EOA pays its
 own gas from a Sepolia faucet.
 
-> **Known Openfort-side issue.** The first write from an undelegated 7702 account takes
-> ~30s to build server-side, and the edge cuts the request at 15s — it surfaces as viem's
-> `Transaction creation failed … Details: Network Error`, and the account never delegates.
-> Until that is fixed, leave the sponsorship id empty and run self-paid.
+Writes are submitted as **sponsored UserOperations** through Openfort's bundler and
+paymaster (`api.openfort.io/rpc/<chainId>`) rather than through `POST /v1/transaction_intents`.
+The delegated account's first write has to carry an EIP-7702 authorization, and building
+that server-side takes ~30s while the edge cuts the request at 15s — so the account never
+delegates and every sponsored write fails as `Transaction creation failed … Network Error`.
+Built client-side it takes ~1.4s, and the delegation rides along in the same operation.
+
+It delegates to **Calibur**, the implementation Openfort uses natively, so once the first
+operation lands the SDK's own delegation check passes and its normal send path works too.
+See [`src/openfort/calibur.ts`](src/openfort/calibur.ts) — EntryPoint v0.9, callData is
+`executeUserOp` ++ `abi.encode(BatchedCall)`, and the signature is wrapped as
+`abi.encode(ROOT_KEY_HASH, signature, hookData)`.
 
 Runs on **Ethereum Sepolia** by default (works with Openfort test keys); set
 `VITE_NETWORK=mainnet` to point at the live mainnet deployment.
@@ -90,7 +98,8 @@ The phone UI is this app's own — Openfort's modal never opens. `OpenfortProvid
 | ---- | ---- | ---- |
 | Sign in | `useEmailOtpAuth` | `screens/Auth.tsx` |
 | Create / unlock a wallet | `useEthereumEmbeddedWallet` → `create` / `setActive` | `screens/Wallets.tsx` |
-| Read + write the chain | `usePublicClient` / `useWalletClient` (wagmi) | `components/Dashboard.tsx` |
+| Read the chain | `usePublicClient` (wagmi) | `components/Dashboard.tsx` |
+| Write the chain, sponsored | `use7702Authorization` + viem `bundlerClient` | `openfort/calibur.ts` |
 
 `connectOnLogin: false` keeps the SDK from picking a wallet behind the login, so the
 passkey prompt only ever fires from the button that asks for it. Wallet actions resolve

--- a/zama-confidential-yield/README.md
+++ b/zama-confidential-yield/README.md
@@ -70,13 +70,33 @@ Deposits/redeems are **batched**: your encrypted amount joins the current batch,
 operator settles it off-chain (`Open → Dispatched → Finalized`), then you `claim`. The UI
 surfaces each batch's status so you can claim when it's ready.
 
+### Headless Openfort
+
+The phone UI is this app's own — Openfort's modal never opens. `OpenfortProvider` takes a
+`walletConfig` and no `uiConfig`, and every step is a hook, following the
+[headless quickstart](https://github.com/openfort-xyz/openfort-react/tree/main/examples/quickstarts/headless):
+
+| Step | Hook | File |
+| ---- | ---- | ---- |
+| Sign in | `useEmailOtpAuth` | `screens/Auth.tsx` |
+| Create / unlock a wallet | `useEthereumEmbeddedWallet` → `create` / `setActive` | `screens/Wallets.tsx` |
+| Read + write the chain | `usePublicClient` / `useWalletClient` (wagmi) | `components/Dashboard.tsx` |
+
+`connectOnLogin: false` keeps the SDK from picking a wallet behind the login, so the
+passkey prompt only ever fires from the button that asks for it. Wallet actions resolve
+with `{ error }` rather than rejecting — branch on the result, don't wrap them in `try`.
+
+`OpenfortWagmiBridge` connects the embedded wallet as a wagmi connector, so the Zama SDK
+gets ordinary viem clients (`makeRuntime` in `zama/sdk.ts`) and nothing in the app handles
+an EIP-1193 provider directly.
+
 ## Project layout
 
 ```
 src/
-  openfort/   Providers.tsx (EOA/passkey + sponsorship), wagmi.ts
-  zama/       sdk.ts (ZamaSDK ← Openfort viem clients), confidential.ts (shield/unshield/deposit/redeem/claim/decrypt)
-  contracts/  addresses.ts (Sepolia + mainnet), abis.ts
+  openfort/   Providers.tsx (headless config: delegated account + sponsorship), wagmi.ts
+  zama/       sdk.ts (ZamaSDK ← wagmi's viem clients), confidential.ts (shield/unshield/deposit/redeem/claim/decrypt)
+  contracts/  addresses.ts (Sepolia + mainnet, RPC), abis.ts
   components/ PhoneFrame.tsx, Dashboard.tsx, BatchStatus.tsx, ui.tsx, styles.ts
   screens/    Auth.tsx (email OTP), Wallets.tsx (create/recover w/ passkey)
 ```

--- a/zama-confidential-yield/README.md
+++ b/zama-confidential-yield/README.md
@@ -2,8 +2,18 @@
 
 Shield USDC into Zama's confidential token (**cUSDC**) and earn private yield in the
 **Steakhouse Confidential** Morpho vault, from an Openfort embedded wallet. Balances,
-deposits and yield stay **encrypted** on-chain. The wallet is an **EOA + passkey**,
-EIP-7702-delegated so an Openfort **paymaster** sponsors every transaction.
+deposits and yield stay **encrypted** on-chain.
+
+The wallet is an **EOA + passkey**. It has to be an EOA: Zama's relayer `ecrecover`s the
+decryption permit against your address, so a 4337 smart account would decrypt nothing.
+Set `VITE_OPENFORT_FEE_SPONSORSHIP_ID` and that same EOA is EIP-7702-delegated so an
+Openfort **paymaster** sponsors every transaction; leave it empty and the EOA pays its
+own gas from a Sepolia faucet.
+
+> **Known Openfort-side issue.** The first write from an undelegated 7702 account takes
+> ~30s to build server-side, and the edge cuts the request at 15s — it surfaces as viem's
+> `Transaction creation failed … Details: Network Error`, and the account never delegates.
+> Until that is fixed, leave the sponsorship id empty and run self-paid.
 
 Runs on **Ethereum Sepolia** by default (works with Openfort test keys); set
 `VITE_NETWORK=mainnet` to point at the live mainnet deployment.
@@ -39,7 +49,7 @@ Copy `.env.example` to `.env` and fill it in:
 VITE_NETWORK=sepolia
 VITE_OPENFORT_PUBLISHABLE_KEY=pk_test_...
 VITE_OPENFORT_SHIELD_KEY=...
-VITE_OPENFORT_FEE_SPONSORSHIP_ID=pol_...   # Sepolia policy → sponsored (gasless) txs
+VITE_OPENFORT_FEE_SPONSORSHIP_ID=          # empty → self-paid EOA; pol_… → gasless 7702
 VITE_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
 ```
 

--- a/zama-confidential-yield/package.json
+++ b/zama-confidential-yield/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
-    "@openfort/react": "1.6.0",
+    "@openfort/react": "2.1.0",
     "@tanstack/react-query": "5.101.0",
     "@zama-fhe/sdk": "3.2.0",
     "react": "19.2.7",

--- a/zama-confidential-yield/src/App.tsx
+++ b/zama-confidential-yield/src/App.tsx
@@ -19,13 +19,17 @@ type Step = 'loading' | 'auth' | 'wallet' | 'dashboard'
 function useStep(): Step {
   const { isLoading } = useOpenfort()
   const { isAuthenticated } = useUser()
-  const { isConnected } = useAccount()
+  const { isConnected, status } = useAccount()
   const wallet = useEthereumEmbeddedWallet()
   const busy = wallet.status === 'fetching-wallets' || wallet.isConnecting
 
   if (isLoading) return 'loading'
   if (isAuthenticated && busy) return 'loading'
   if (!isAuthenticated) return 'auth'
+  // `getDefaultConfig` sets wagmi's `ssr: true`, so the first render reports
+  // `reconnecting` with `isConnected` false. Routing on that would flash the
+  // unlock screen over a wallet that is one tick from connecting.
+  if (status === 'reconnecting') return 'loading'
   if (!isConnected || wallet.activeWallet?.accountType !== ACCOUNT_TYPE) return 'wallet'
   return 'dashboard'
 }

--- a/zama-confidential-yield/src/components/BatchStatus.tsx
+++ b/zama-confidential-yield/src/components/BatchStatus.tsx
@@ -6,9 +6,9 @@ import {
   batchInfo,
   claimBatch,
   decryptHandles,
-  type Runtime,
   readBatchPosition,
 } from '../zama/confidential'
+import type { Runtime } from '../zama/sdk'
 import { fontStack, ghostBtn, monoStack, primaryBtn } from './styles'
 
 type Batch = { kind: BatchKind; batchId: bigint; state: number }

--- a/zama-confidential-yield/src/components/Dashboard.tsx
+++ b/zama-confidential-yield/src/components/Dashboard.tsx
@@ -2,7 +2,7 @@ import { useSignOut } from '@openfort/react'
 import { type CSSProperties, useCallback, useEffect, useMemo, useState } from 'react'
 import { formatUnits } from 'viem'
 import { usePublicClient, useWalletClient } from 'wagmi'
-import { ADDRESSES, DECIMALS, FAUCET_URL, NETWORK } from '../contracts/addresses'
+import { ADDRESSES, DECIMALS, FAUCET_URL, GAS_FAUCET_URL, NETWORK } from '../contracts/addresses'
 import {
   type BatchKind,
   decryptHandles,
@@ -33,6 +33,12 @@ const fmt = (v: bigint) =>
 type Pending = { key: string; kind: BatchKind; batchId: bigint; state: number }
 const STATE_LABEL = ['Open', 'Dispatched', 'Ready'] as const
 
+const TABS = [
+  { id: 'balance', icon: '💵', label: 'Balance' },
+  { id: 'earn', icon: '📈', label: 'Earn' },
+] as const
+type TabId = (typeof TABS)[number]['id']
+
 export function Dashboard() {
   const { signOut } = useSignOut()
   // Both clients come from the wagmi config the Openfort connector lives in, so
@@ -55,6 +61,7 @@ export function Dashboard() {
   const [copied, setCopied] = useState(false)
   const [minting, setMinting] = useState(false)
   const [viewKey, setViewKey] = useState<string | null>(null)
+  const [tab, setTab] = useState<TabId>('balance')
 
   const copyAddress = async () => {
     if (!account) return
@@ -134,6 +141,25 @@ export function Dashboard() {
 
   if (!rt || usdc === null) return <Spinner label="Loading balances…" />
 
+  // Both tabs mask values behind the same decryption, so both get the toggle.
+  const revealBlock = (
+    <>
+      <button
+        type="button"
+        onClick={revealed ? () => setRevealed(null) : reveal}
+        disabled={revealing}
+        style={{ ...revealBtn, opacity: revealing ? 0.6 : 1 }}
+      >
+        {revealing
+          ? 'Decrypting…'
+          : revealed
+            ? '🙈  Hide private balances'
+            : '🔓  Reveal private balances'}
+      </button>
+      {err && <p style={errStyle}>{err}</p>}
+    </>
+  )
+
   const viewed = viewKey ? (pending.find((p) => p.key === viewKey) ?? null) : null
   if (viewed) {
     return (
@@ -154,7 +180,7 @@ export function Dashboard() {
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 18, paddingBottom: 74 }}>
       <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <h1
           style={{
@@ -184,184 +210,205 @@ export function Dashboard() {
         </div>
       </header>
 
-      {/* Hero — public USDC */}
-      <div style={hero}>
-        <span style={{ fontFamily: fontStack, fontSize: '0.78rem', opacity: 0.7 }}>
-          USDC · Available
-        </span>
-        <div
-          style={{
-            fontFamily: fontStack,
-            fontWeight: 800,
-            fontSize: '2.6rem',
-            letterSpacing: '-0.03em',
-            lineHeight: 1.1,
-          }}
-        >
-          ${fmt(usdc)}
-        </div>
-        <div style={heroActions}>
-          <button type="button" onClick={copyAddress} style={heroPill} title="Copy wallet address">
-            {copied ? (
-              '✓ Copied'
-            ) : (
-              <>
-                <span style={{ fontFamily: monoStack }}>
-                  {account?.slice(0, 6)}…{account?.slice(-4)}
-                </span>
-                <span aria-hidden>⧉</span>
-              </>
-            )}
-          </button>
-          {NETWORK === 'sepolia' ? (
-            <button
-              type="button"
-              onClick={getUsdc}
-              disabled={minting}
-              style={{ ...heroPill, opacity: minting ? 0.6 : 1 }}
-              title="Mint 100 test USDC to this wallet"
+      {tab === 'balance' && (
+        <>
+          {/* Hero — public USDC */}
+          <div style={hero}>
+            <span style={{ fontFamily: fontStack, fontSize: '0.78rem', opacity: 0.7 }}>
+              USDC · Available
+            </span>
+            <div
+              style={{
+                fontFamily: fontStack,
+                fontWeight: 800,
+                fontSize: '2.6rem',
+                letterSpacing: '-0.03em',
+                lineHeight: 1.1,
+              }}
             >
-              {minting ? 'Minting…' : '＋ Get test USDC'}
-            </button>
-          ) : (
-            <a
-              href={FAUCET_URL}
-              target="_blank"
-              rel="noreferrer"
-              style={heroPill}
-              title="Circle USDC faucet"
-            >
-              Get USDC ↗
-            </a>
-          )}
-        </div>
-      </div>
-
-      <button
-        type="button"
-        onClick={revealed ? () => setRevealed(null) : reveal}
-        disabled={revealing}
-        style={{ ...revealBtn, opacity: revealing ? 0.6 : 1 }}
-      >
-        {revealing
-          ? 'Decrypting…'
-          : revealed
-            ? '🙈  Hide private balances'
-            : '🔓  Reveal private balances'}
-      </button>
-      {err && <p style={errStyle}>{err}</p>}
-
-      {/* Shielded cUSDC */}
-      <section>
-        <p style={sectionLabel}>Shielded</p>
-        <div style={iosCard}>
-          <Row
-            label="cUSDC"
-            sub="confidential"
-            value={revealed ? `$${fmt(revealed.cusdc)}` : '••••'}
-            locked={!revealed}
-          />
-          <Divider />
-          <p style={hint}>
-            Wrap public USDC into encrypted cUSDC and back. The shield amount is visible; balances
-            stay private.
-          </p>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            <AmountAction
-              buttonText="Shield"
-              unit="USDC"
-              onSubmit={async (a) => {
-                await shield(rt, a)
-                return after('Shielded into cUSDC.')()
-              }}
-            />
-            <AmountAction
-              buttonText="Unshield"
-              unit="cUSDC"
-              onSubmit={async (a) => {
-                await unshield(rt, a)
-                return after('Unshielded to USDC.')()
-              }}
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* Earn — confidential vault */}
-      <section>
-        <p style={sectionLabel}>Earn · private yield</p>
-        <div style={iosCard}>
-          <Row
-            label="In vault"
-            sub="cUSDC + yield"
-            value={revealed ? `$${fmt(revealed.vaultUsdc)}` : '••••'}
-            locked={!revealed}
-            badge="~4% APY"
-          />
-          <Divider />
-          <p style={hint}>
-            Deposit cUSDC to earn ~4% privately; your position shows in cUSDC and grows as the vault
-            earns. (Internally it's an ERC-4626 vault that issues appreciating{' '}
-            <strong>shares</strong> — the value above already converts them back to cUSDC.) Deposits
-            join a <strong>batch</strong>; tap a pending batch below to claim once it settles.
-          </p>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            <AmountAction
-              buttonText="Deposit"
-              unit="cUSDC"
-              onSubmit={async (a) => {
-                const id = await vaultDeposit(rt, a)
-                addBatch('deposit', id)
-                return after(`Joined deposit batch #${id}.`)()
-              }}
-            />
-            <AmountAction
-              buttonText="Redeem"
-              unit="shares"
-              onSubmit={async (a) => {
-                const id = await vaultRedeem(rt, a)
-                addBatch('redeem', id)
-                return after(`Joined redeem batch #${id}.`)()
-              }}
-            />
-          </div>
-        </div>
-      </section>
-
-      {pending.length > 0 && (
-        <section>
-          <p style={sectionLabel}>Pending batches</p>
-          <div style={{ ...iosCard, padding: 6 }}>
-            {pending.map((b) => (
-              <button key={b.key} type="button" onClick={() => setViewKey(b.key)} style={batchRow}>
-                <div style={{ textAlign: 'left' }}>
-                  <p
-                    style={{
-                      margin: 0,
-                      fontFamily: fontStack,
-                      fontWeight: 600,
-                      fontSize: '0.85rem',
-                    }}
-                  >
-                    {b.kind === 'deposit' ? 'Deposit' : 'Redeem'} batch #{b.batchId.toString()}
-                  </p>
-                  <p
-                    style={{
-                      margin: '2px 0 0',
-                      fontFamily: fontStack,
-                      fontSize: '0.72rem',
-                      color: b.state >= 2 ? 'var(--pd-success)' : 'var(--pd-ink-400)',
-                    }}
-                  >
-                    {STATE_LABEL[b.state] ?? 'Open'}
-                    {b.state >= 2 ? ' · tap to claim' : ' · tap for status'}
-                  </p>
-                </div>
-                <span style={{ color: 'var(--pd-ink-400)', fontSize: '1.2rem' }}>›</span>
+              ${fmt(usdc)}
+            </div>
+            <div style={heroActions}>
+              <button
+                type="button"
+                onClick={copyAddress}
+                style={heroPill}
+                title="Copy wallet address"
+              >
+                {copied ? (
+                  '✓ Copied'
+                ) : (
+                  <>
+                    <span style={{ fontFamily: monoStack }}>
+                      {account?.slice(0, 6)}…{account?.slice(-4)}
+                    </span>
+                    <span aria-hidden>⧉</span>
+                  </>
+                )}
               </button>
-            ))}
+              {NETWORK === 'sepolia' ? (
+                <button
+                  type="button"
+                  onClick={getUsdc}
+                  disabled={minting}
+                  style={{ ...heroPill, opacity: minting ? 0.6 : 1 }}
+                  title="Mint 100 test USDC to this wallet"
+                >
+                  {minting ? 'Minting…' : '＋ Get test USDC'}
+                </button>
+              ) : (
+                <a
+                  href={FAUCET_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={heroPill}
+                  title="Circle USDC faucet"
+                >
+                  Get USDC ↗
+                </a>
+              )}
+              {/* Unsponsored: every action costs gas, so surface the ETH faucet. */}
+              {!GASLESS && NETWORK === 'sepolia' && (
+                <a
+                  href={GAS_FAUCET_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={heroPill}
+                  title="Sepolia ETH for gas"
+                >
+                  ⛽ Get ETH ↗
+                </a>
+              )}
+            </div>
           </div>
-        </section>
+
+          {revealBlock}
+
+          {/* Shielded cUSDC */}
+          <section>
+            <p style={sectionLabel}>Shielded</p>
+            <div style={iosCard}>
+              <Row
+                label="cUSDC"
+                sub="confidential"
+                value={revealed ? `$${fmt(revealed.cusdc)}` : '••••'}
+                locked={!revealed}
+              />
+              <Divider />
+              <p style={hint}>
+                Wrap public USDC into encrypted cUSDC and back. The shield amount is visible;
+                balances stay private.
+              </p>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                <AmountAction
+                  buttonText="Shield"
+                  unit="USDC"
+                  onSubmit={async (a) => {
+                    await shield(rt, a)
+                    return after('Shielded into cUSDC.')()
+                  }}
+                />
+                <AmountAction
+                  buttonText="Unshield"
+                  unit="cUSDC"
+                  onSubmit={async (a) => {
+                    await unshield(rt, a)
+                    return after('Unshielded to USDC.')()
+                  }}
+                />
+              </div>
+            </div>
+          </section>
+        </>
+      )}
+
+      {tab === 'earn' && (
+        <>
+          {revealBlock}
+
+          {/* Earn — confidential vault */}
+          <section>
+            <p style={sectionLabel}>Earn · private yield</p>
+            <div style={iosCard}>
+              <Row
+                label="In vault"
+                sub="cUSDC + yield"
+                value={revealed ? `$${fmt(revealed.vaultUsdc)}` : '••••'}
+                locked={!revealed}
+                badge="~4% APY"
+              />
+              <Divider />
+              <p style={hint}>
+                Deposit cUSDC to earn ~4% privately; your position shows in cUSDC and grows as the
+                vault earns. (Internally it's an ERC-4626 vault that issues appreciating{' '}
+                <strong>shares</strong> — the value above already converts them back to cUSDC.)
+                Deposits join a <strong>batch</strong>; tap a pending batch below to claim once it
+                settles.
+              </p>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                <AmountAction
+                  buttonText="Deposit"
+                  unit="cUSDC"
+                  onSubmit={async (a) => {
+                    const id = await vaultDeposit(rt, a)
+                    addBatch('deposit', id)
+                    return after(`Joined deposit batch #${id}.`)()
+                  }}
+                />
+                <AmountAction
+                  buttonText="Redeem"
+                  unit="shares"
+                  onSubmit={async (a) => {
+                    const id = await vaultRedeem(rt, a)
+                    addBatch('redeem', id)
+                    return after(`Joined redeem batch #${id}.`)()
+                  }}
+                />
+              </div>
+            </div>
+          </section>
+
+          {pending.length > 0 && (
+            <section>
+              <p style={sectionLabel}>Pending batches</p>
+              <div style={{ ...iosCard, padding: 6 }}>
+                {pending.map((b) => (
+                  <button
+                    key={b.key}
+                    type="button"
+                    onClick={() => setViewKey(b.key)}
+                    style={batchRow}
+                  >
+                    <div style={{ textAlign: 'left' }}>
+                      <p
+                        style={{
+                          margin: 0,
+                          fontFamily: fontStack,
+                          fontWeight: 600,
+                          fontSize: '0.85rem',
+                        }}
+                      >
+                        {b.kind === 'deposit' ? 'Deposit' : 'Redeem'} batch #{b.batchId.toString()}
+                      </p>
+                      <p
+                        style={{
+                          margin: '2px 0 0',
+                          fontFamily: fontStack,
+                          fontSize: '0.72rem',
+                          color: b.state >= 2 ? 'var(--pd-success)' : 'var(--pd-ink-400)',
+                        }}
+                      >
+                        {STATE_LABEL[b.state] ?? 'Open'}
+                        {b.state >= 2 ? ' · tap to claim' : ' · tap for status'}
+                      </p>
+                    </div>
+                    <span style={{ color: 'var(--pd-ink-400)', fontSize: '1.2rem' }}>›</span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+        </>
       )}
 
       <footer style={{ textAlign: 'center', padding: '4px 0 8px' }}>
@@ -369,7 +416,47 @@ export function Dashboard() {
           Openfort wallet · Zama cUSDC · Ethereum {NETWORK === 'mainnet' ? 'mainnet' : 'Sepolia'}
         </span>
       </footer>
+
+      <TabBar tab={tab} onTab={setTab} pending={pending.length} />
     </div>
+  )
+}
+
+/**
+ * Floating iOS-style tab bar. `PhoneFrame`'s screen is the nearest positioned
+ * ancestor and the scroll container is inside it, so `position: absolute` pins
+ * the bar to the phone's bottom edge instead of scrolling away with the content.
+ */
+function TabBar({
+  tab,
+  onTab,
+  pending,
+}: {
+  tab: TabId
+  onTab: (tab: TabId) => void
+  pending: number
+}) {
+  return (
+    <nav style={tabBar}>
+      {TABS.map(({ id, icon, label }) => {
+        const active = tab === id
+        return (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onTab(id)}
+            style={{ ...tabItem, ...(active ? tabItemActive : null) }}
+            aria-current={active ? 'page' : undefined}
+          >
+            <span style={{ fontSize: '1.05rem', lineHeight: 1 }} aria-hidden>
+              {icon}
+            </span>
+            <span>{label}</span>
+            {id === 'earn' && pending > 0 && <span style={tabBadge}>{pending}</span>}
+          </button>
+        )
+      })}
+    </nav>
   )
 }
 
@@ -431,6 +518,59 @@ const Divider = () => (
   <div style={{ height: 1, background: 'var(--demo-border)', margin: '12px 0' }} />
 )
 
+const tabBar: CSSProperties = {
+  position: 'absolute',
+  left: 16,
+  right: 16,
+  bottom: 14,
+  zIndex: 15,
+  display: 'grid',
+  gridAutoFlow: 'column',
+  gridAutoColumns: '1fr',
+  gap: 4,
+  padding: 5,
+  borderRadius: 999,
+  background: 'color-mix(in srgb, var(--pd-surface) 82%, transparent)',
+  backdropFilter: 'blur(20px) saturate(180%)',
+  WebkitBackdropFilter: 'blur(20px) saturate(180%)',
+  border: '1px solid var(--demo-border)',
+  boxShadow: '0 10px 28px rgba(15,23,42,.16)',
+}
+const tabItem: CSSProperties = {
+  position: 'relative',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 7,
+  padding: '9px 12px',
+  borderRadius: 999,
+  border: 'none',
+  background: 'none',
+  color: 'var(--pd-ink-500)',
+  fontFamily: fontStack,
+  fontSize: '0.82rem',
+  fontWeight: 600,
+  cursor: 'pointer',
+  transition: 'background .18s ease, color .18s ease',
+}
+const tabItemActive: CSSProperties = {
+  background: 'var(--pd-surface-muted)',
+  color: 'var(--pd-ink-900)',
+}
+const tabBadge: CSSProperties = {
+  minWidth: 17,
+  height: 17,
+  padding: '0 5px',
+  borderRadius: 999,
+  background: 'var(--pd-brand)',
+  color: '#fff',
+  fontFamily: fontStack,
+  fontSize: '0.64rem',
+  fontWeight: 700,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
 const hero: CSSProperties = {
   borderRadius: 22,
   padding: '20px 22px',

--- a/zama-confidential-yield/src/components/Dashboard.tsx
+++ b/zama-confidential-yield/src/components/Dashboard.tsx
@@ -1,15 +1,13 @@
 import { useSignOut } from '@openfort/react'
-import { useEthereumEmbeddedWallet } from '@openfort/react/ethereum'
 import { type CSSProperties, useCallback, useEffect, useMemo, useState } from 'react'
-import { type EIP1193Provider, formatUnits } from 'viem'
+import { formatUnits } from 'viem'
+import { usePublicClient, useWalletClient } from 'wagmi'
 import { ADDRESSES, DECIMALS, FAUCET_URL, NETWORK } from '../contracts/addresses'
 import {
   type BatchKind,
   decryptHandles,
   type HandleRef,
-  makeClients,
   mintTestUsdc,
-  type Runtime,
   readEncryptedHandle,
   readUsdcBalance,
   shield,
@@ -18,6 +16,7 @@ import {
   vaultRedeem,
   vaultValueUsdc,
 } from '../zama/confidential'
+import { makeRuntime, type Runtime } from '../zama/sdk'
 import { BatchStatus } from './BatchStatus'
 import { chip, fontStack, ghostBtn, iosCard, monoStack, sectionLabel } from './styles'
 import { AmountAction, Spinner } from './ui'
@@ -35,14 +34,16 @@ type Pending = { key: string; kind: BatchKind; batchId: bigint; state: number }
 const STATE_LABEL = ['Open', 'Dispatched', 'Ready'] as const
 
 export function Dashboard() {
-  const wallet = useEthereumEmbeddedWallet()
   const { signOut } = useSignOut()
-  const account = wallet.activeWallet?.address as Hex | undefined
-  const provider =
-    'provider' in wallet ? (wallet.provider as EIP1193Provider | undefined) : undefined
+  // Both clients come from the wagmi config the Openfort connector lives in, so
+  // the wallet client is the embedded wallet and the public client reads from
+  // the same RPC. Zama's SDK takes plain viem clients — no provider plumbing.
+  const publicClient = usePublicClient()
+  const { data: walletClient } = useWalletClient()
+  const account = walletClient?.account.address
   const rt = useMemo<Runtime | null>(
-    () => (provider && account ? makeClients(provider, account) : null),
-    [provider, account]
+    () => (publicClient && walletClient ? makeRuntime(publicClient, walletClient) : null),
+    [publicClient, walletClient]
   )
 
   const [usdc, setUsdc] = useState<bigint | null>(null)

--- a/zama-confidential-yield/src/components/Dashboard.tsx
+++ b/zama-confidential-yield/src/components/Dashboard.tsx
@@ -3,6 +3,7 @@ import { type CSSProperties, useCallback, useEffect, useMemo, useState } from 'r
 import { formatUnits } from 'viem'
 import { usePublicClient, useWalletClient } from 'wagmi'
 import { ADDRESSES, DECIMALS, FAUCET_URL, GAS_FAUCET_URL, NETWORK } from '../contracts/addresses'
+import { useSponsoredSender } from '../openfort/useSponsoredSender'
 import {
   type BatchKind,
   decryptHandles,
@@ -47,9 +48,12 @@ export function Dashboard() {
   const publicClient = usePublicClient()
   const { data: walletClient } = useWalletClient()
   const account = walletClient?.account.address
+  // Writes go out as sponsored UserOperations through Openfort's bundler, not
+  // through the wallet client — see openfort/calibur.ts.
+  const send = useSponsoredSender(publicClient, account)
   const rt = useMemo<Runtime | null>(
-    () => (publicClient && walletClient ? makeRuntime(publicClient, walletClient) : null),
-    [publicClient, walletClient]
+    () => (publicClient && walletClient ? makeRuntime(publicClient, walletClient, send) : null),
+    [publicClient, walletClient, send]
   )
 
   const [usdc, setUsdc] = useState<bigint | null>(null)

--- a/zama-confidential-yield/src/components/Dashboard.tsx
+++ b/zama-confidential-yield/src/components/Dashboard.tsx
@@ -292,10 +292,9 @@ export function Dashboard() {
           <section>
             <p style={sectionLabel}>Shielded</p>
             <div style={iosCard}>
-              <Row
-                label="cUSDC"
-                sub="confidential"
-                value={revealed ? `$${fmt(revealed.cusdc)}` : '••••'}
+              <BalancePair
+                publicValue={`$${fmt(usdc)}`}
+                shieldedValue={revealed ? `$${fmt(revealed.cusdc)}` : '••••'}
                 locked={!revealed}
               />
               <Divider />
@@ -334,6 +333,12 @@ export function Dashboard() {
           <section>
             <p style={sectionLabel}>Earn · private yield</p>
             <div style={iosCard}>
+              <BalancePair
+                publicValue={`$${fmt(usdc)}`}
+                shieldedValue={revealed ? `$${fmt(revealed.cusdc)}` : '••••'}
+                locked={!revealed}
+              />
+              <Divider />
               <Row
                 label="In vault"
                 sub="cUSDC + yield"
@@ -464,6 +469,33 @@ function TabBar({
   )
 }
 
+/** Public and shielded side by side, so neither section hides half the picture. */
+function BalancePair({
+  publicValue,
+  shieldedValue,
+  locked,
+}: {
+  publicValue: string
+  shieldedValue: string
+  locked?: boolean
+}) {
+  return (
+    <div style={pairRow}>
+      <div style={pairCell}>
+        <p style={pairLabel}>USDC · public</p>
+        <span style={pairValue}>{publicValue}</span>
+      </div>
+      <div style={pairSplit} />
+      <div style={pairCell}>
+        <p style={pairLabel}>cUSDC · shielded</p>
+        <span style={{ ...pairValue, color: locked ? 'var(--pd-ink-400)' : 'var(--pd-private)' }}>
+          {locked ? `🔒 ${shieldedValue}` : shieldedValue}
+        </span>
+      </div>
+    </div>
+  )
+}
+
 function Row({
   label,
   sub,
@@ -574,6 +606,27 @@ const tabBadge: CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
+}
+const pairRow: CSSProperties = {
+  display: 'flex',
+  alignItems: 'stretch',
+  gap: 12,
+  paddingBottom: 4,
+}
+const pairCell: CSSProperties = { flex: 1, minWidth: 0 }
+const pairSplit: CSSProperties = { width: 1, background: 'var(--demo-border)' }
+const pairLabel: CSSProperties = {
+  margin: '0 0 3px',
+  fontFamily: fontStack,
+  fontSize: '0.7rem',
+  fontWeight: 600,
+  color: 'var(--pd-ink-400)',
+}
+const pairValue: CSSProperties = {
+  fontFamily: monoStack,
+  fontWeight: 700,
+  fontSize: '1.1rem',
+  letterSpacing: '-0.01em',
 }
 const hero: CSSProperties = {
   borderRadius: 22,

--- a/zama-confidential-yield/src/contracts/addresses.ts
+++ b/zama-confidential-yield/src/contracts/addresses.ts
@@ -61,3 +61,6 @@ export const RPC_URL: string =
 
 /** Circle's testnet USDC faucet (Sepolia); harmless on mainnet. */
 export const FAUCET_URL = 'https://faucet.circle.com'
+
+/** Sepolia ETH for gas — only needed when transactions aren't sponsored. */
+export const GAS_FAUCET_URL = 'https://cloud.google.com/application/web3/faucet/ethereum/sepolia'

--- a/zama-confidential-yield/src/contracts/addresses.ts
+++ b/zama-confidential-yield/src/contracts/addresses.ts
@@ -48,5 +48,16 @@ export const CHAIN = ACTIVE.viemChain
 export const CHAIN_ID = ACTIVE.viemChain.id
 export const ADDRESSES = ACTIVE.addresses
 export const DECIMALS = 6
+
+/**
+ * One RPC endpoint for the whole app: wagmi's transport, the Openfort embedded
+ * provider (`walletConfig.ethereum.rpcUrls`) and the Zama SDK's FHE chain all
+ * read it, so a write and the read that confirms it never hit different nodes.
+ * The chain's public default is a fallback — set `VITE_RPC_URL` for anything
+ * real, the Zama relayer is flaky behind rate-limited public RPCs.
+ */
+export const RPC_URL: string =
+  import.meta.env.VITE_RPC_URL || ACTIVE.viemChain.rpcUrls.default.http[0]
+
 /** Circle's testnet USDC faucet (Sepolia); harmless on mainnet. */
 export const FAUCET_URL = 'https://faucet.circle.com'

--- a/zama-confidential-yield/src/openfort/Providers.tsx
+++ b/zama-confidential-yield/src/openfort/Providers.tsx
@@ -1,14 +1,9 @@
-import {
-  AccountTypeEnum,
-  AuthProvider,
-  ChainTypeEnum,
-  OpenfortProvider,
-  RecoveryMethod,
-} from '@openfort/react'
+import { AccountTypeEnum, OpenfortProvider } from '@openfort/react'
 import { OpenfortWagmiBridge } from '@openfort/react/wagmi'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { WagmiProvider } from 'wagmi'
+import { CHAIN_ID, RPC_URL } from '../contracts/addresses'
 import { wagmiConfig } from './wagmi'
 
 const queryClient = new QueryClient()
@@ -17,15 +12,26 @@ const queryClient = new QueryClient()
  * The embedded wallet is an EIP-7702 **delegated account**: the EOA is delegated
  * to a smart account so an Openfort paymaster can sponsor every transaction.
  * `ethereumFeeSponsorshipId` (a `pol_…` policy id) is what the provider resolves
- * per chain (`resolveEthereumFeeSponsorship`) to route writes as sponsored
- * userops. Set it to actually sponsor; without it the delegated account pays its
- * own gas. The signing key stays the embedded EOA key (ECDSA), which is what
- * Zama's `userDecrypt` EIP-712 verification needs.
+ * per chain to route writes as sponsored userops. Set it to actually sponsor;
+ * without it the delegated account pays its own gas. The signing key stays the
+ * embedded EOA key (ECDSA), which is what Zama's `userDecrypt` EIP-712 needs.
  */
 const FEE_SPONSORSHIP_ID = import.meta.env.VITE_OPENFORT_FEE_SPONSORSHIP_ID || undefined
 
 export const ACCOUNT_TYPE = AccountTypeEnum.DELEGATED_ACCOUNT
 
+/**
+ * Headless Openfort: no `uiConfig`, because this app never opens the Openfort
+ * modal. `screens/Auth` drives `useEmailOtpAuth` and `screens/Wallets` drives
+ * `useEthereumEmbeddedWallet` itself, the way
+ * https://github.com/openfort-xyz/openfort-react/tree/main/examples/quickstarts/headless
+ * does — the phone UI is ours end to end.
+ *
+ * `connectOnLogin: false` is the other half of that: the SDK does not pick or
+ * create a wallet behind the login, so `screens/Wallets` stays the only thing
+ * that calls `create()` / `setActive()` and the passkey prompt never fires
+ * unprompted.
+ */
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
@@ -34,19 +40,15 @@ export function Providers({ children }: { children: ReactNode }) {
           <OpenfortProvider
             publishableKey={import.meta.env.VITE_OPENFORT_PUBLISHABLE_KEY}
             walletConfig={{
-              chainType: ChainTypeEnum.EVM,
               shieldPublishableKey: import.meta.env.VITE_OPENFORT_SHIELD_KEY,
+              connectOnLogin: false,
               ethereum: {
                 accountType: ACCOUNT_TYPE,
                 ethereumFeeSponsorshipId: FEE_SPONSORSHIP_ID,
-              },
-            }}
-            uiConfig={{
-              mode: 'light',
-              authProviders: [AuthProvider.EMAIL_OTP, AuthProvider.GOOGLE],
-              walletRecovery: {
-                allowedMethods: [RecoveryMethod.PASSKEY],
-                defaultMethod: RecoveryMethod.PASSKEY,
+                // The SDK memoizes the first provider it builds, including during
+                // `create()`, so pass the endpoint here too — otherwise wallet
+                // creation runs against the SDK's public defaults.
+                rpcUrls: { [CHAIN_ID]: RPC_URL },
               },
             }}
           >

--- a/zama-confidential-yield/src/openfort/Providers.tsx
+++ b/zama-confidential-yield/src/openfort/Providers.tsx
@@ -24,7 +24,7 @@ const queryClient = new QueryClient()
  * the account never gets delegated. Until that is fixed, unset the sponsorship
  * id to run self-paid (fund the wallet with Sepolia ETH).
  */
-const FEE_SPONSORSHIP_ID = import.meta.env.VITE_OPENFORT_FEE_SPONSORSHIP_ID || undefined
+export const FEE_SPONSORSHIP_ID = import.meta.env.VITE_OPENFORT_FEE_SPONSORSHIP_ID || undefined
 
 export const ACCOUNT_TYPE = FEE_SPONSORSHIP_ID
   ? AccountTypeEnum.DELEGATED_ACCOUNT

--- a/zama-confidential-yield/src/openfort/Providers.tsx
+++ b/zama-confidential-yield/src/openfort/Providers.tsx
@@ -9,16 +9,26 @@ import { wagmiConfig } from './wagmi'
 const queryClient = new QueryClient()
 
 /**
- * The embedded wallet is an EIP-7702 **delegated account**: the EOA is delegated
- * to a smart account so an Openfort paymaster can sponsor every transaction.
- * `ethereumFeeSponsorshipId` (a `pol_…` policy id) is what the provider resolves
- * per chain to route writes as sponsored userops. Set it to actually sponsor;
- * without it the delegated account pays its own gas. The signing key stays the
- * embedded EOA key (ECDSA), which is what Zama's `userDecrypt` EIP-712 needs.
+ * The wallet is an **EOA** either way — Zama's `userDecrypt` EIP-712 permit is
+ * verified with `ecrecover` against the user address, so the signer has to be a
+ * plain ECDSA key (a 4337 smart account would decrypt nothing).
+ *
+ * Setting `VITE_OPENFORT_FEE_SPONSORSHIP_ID` (a `pol_…` id) upgrades that EOA to
+ * an EIP-7702 **delegated account** so an Openfort paymaster can sponsor every
+ * transaction; the address and the signing key are unchanged. Leave it unset and
+ * the same EOA pays its own gas.
+ *
+ * Known Openfort-side issue: the *first* write from an undelegated 7702 account
+ * takes ~30s to build server-side and Cloudflare cuts the request at 15s, so it
+ * surfaces as viem's `Transaction creation failed … Details: Network Error` and
+ * the account never gets delegated. Until that is fixed, unset the sponsorship
+ * id to run self-paid (fund the wallet with Sepolia ETH).
  */
 const FEE_SPONSORSHIP_ID = import.meta.env.VITE_OPENFORT_FEE_SPONSORSHIP_ID || undefined
 
-export const ACCOUNT_TYPE = AccountTypeEnum.DELEGATED_ACCOUNT
+export const ACCOUNT_TYPE = FEE_SPONSORSHIP_ID
+  ? AccountTypeEnum.DELEGATED_ACCOUNT
+  : AccountTypeEnum.EOA
 
 /**
  * Headless Openfort: no `uiConfig`, because this app never opens the Openfort

--- a/zama-confidential-yield/src/openfort/calibur.ts
+++ b/zama-confidential-yield/src/openfort/calibur.ts
@@ -1,0 +1,234 @@
+import {
+  type Address,
+  concatHex,
+  encodeAbiParameters,
+  encodeFunctionData,
+  type Hex,
+  http,
+  type PublicClient,
+} from 'viem'
+import {
+  createBundlerClient,
+  createPaymasterClient,
+  entryPoint09Abi,
+  entryPoint09Address,
+  getUserOperationHash,
+  type SmartAccount,
+  toSmartAccount,
+} from 'viem/account-abstraction'
+import { CHAIN, CHAIN_ID } from '../contracts/addresses'
+
+/**
+ * Send the recipe's writes as sponsored UserOperations through Openfort's
+ * bundler + paymaster, instead of `POST /v1/transaction_intents`.
+ *
+ * Why: a Delegated Account's first write has to carry an EIP-7702 authorization,
+ * and building that server-side takes ~30s while the edge cuts the request at
+ * 15s — so the account never delegates and every sponsored write dies as
+ * "Transaction creation failed … Network Error". Building the UserOperation here
+ * takes ~1.4s, and the delegation rides along in the same operation.
+ *
+ * We delegate to Calibur, the implementation Openfort uses natively, so once the
+ * first operation lands the SDK's own `isDelegatedToImplementation` check passes
+ * and its normal path works too.
+ */
+
+/** One call inside a batched UserOperation. */
+export type Call = { to: Address; value?: bigint; data?: Hex }
+
+/** Calibur implementation per chain. Openfort registers it as "CaliburV9". */
+const CALIBUR_IMPLEMENTATION: Record<number, Address> = {
+  11155111: '0x0909bABe99b0A5f8C1fbfcD5E2510E6c15082c53',
+}
+
+export function caliburImplementation(): Address {
+  const address =
+    (import.meta.env.VITE_CALIBUR_IMPLEMENTATION as Address | undefined) ||
+    CALIBUR_IMPLEMENTATION[CHAIN_ID]
+  if (!address) {
+    throw new Error(
+      `No Calibur implementation known for chain ${CHAIN_ID}. Look it up at ` +
+        `https://www.openfort.io/docs/configuration/addresses and set VITE_CALIBUR_IMPLEMENTATION.`
+    )
+  }
+  return address
+}
+
+/** `executeUserOp(PackedUserOperation,bytes32)` — Calibur reads its calls from the tail. */
+const EXECUTE_USER_OP_SELECTOR = '0x8dd7712f'
+
+/** BatchedCall { Call[] calls; bool revertOnFailure; }, Call { address to; uint256 value; bytes data; } */
+const BATCHED_CALL = [
+  {
+    type: 'tuple',
+    components: [
+      {
+        name: 'calls',
+        type: 'tuple[]',
+        components: [
+          { name: 'to', type: 'address' },
+          { name: 'value', type: 'uint256' },
+          { name: 'data', type: 'bytes' },
+        ],
+      },
+      { name: 'revertOnFailure', type: 'bool' },
+    ],
+  },
+] as const
+
+/**
+ * Calibur expects `abi.encode(keyHash, signature, hookData)`. `bytes32(0)` is
+ * `ROOT_KEY_HASH`, the account's own key. Openfort's build rejects a bare
+ * 65-byte signature with `SliceOutOfBounds()`, unlike upstream Calibur.
+ */
+const ROOT_KEY_HASH = `0x${'00'.repeat(32)}` as Hex
+
+function wrapSignature(signature: Hex): Hex {
+  return encodeAbiParameters(
+    [{ type: 'bytes32' }, { type: 'bytes' }, { type: 'bytes' }],
+    [ROOT_KEY_HASH, signature, '0x']
+  )
+}
+
+/** A structurally valid secp256k1 signature, so gas estimation recovers a wrong
+ *  address instead of reverting inside Calibur's ECDSA check. */
+const STUB_SIGNATURE = wrapSignature(`0x${'11'.repeat(32)}${'22'.repeat(32)}1b` as Hex)
+
+/** Signs a 32-byte hash with no EIP-191 prefix — what Calibur's root key verifies. */
+export type RawHashSigner = (hash: Hex) => Promise<Hex>
+
+export async function toCaliburSmartAccount({
+  client,
+  address,
+  signHash,
+}: {
+  client: PublicClient
+  address: Address
+  signHash: RawHashSigner
+}): Promise<SmartAccount> {
+  return toSmartAccount({
+    client,
+    entryPoint: { abi: entryPoint09Abi, address: entryPoint09Address, version: '0.9' },
+    async getAddress() {
+      return address
+    },
+    // EIP-7702: the delegation puts the code there, no factory deploys anything.
+    async getFactoryArgs() {
+      return { factory: '0x7702', factoryData: '0x' }
+    },
+    async encodeCalls(calls: readonly Call[]) {
+      return concatHex([
+        EXECUTE_USER_OP_SELECTOR,
+        encodeAbiParameters(BATCHED_CALL, [
+          {
+            calls: calls.map((call) => ({
+              to: call.to,
+              value: call.value ?? 0n,
+              data: call.data ?? '0x',
+            })),
+            revertOnFailure: true,
+          },
+        ]),
+      ])
+    },
+    async getNonce({ key = 0n } = {}) {
+      return client.readContract({
+        address: entryPoint09Address,
+        abi: entryPoint09Abi,
+        functionName: 'getNonce',
+        args: [address, key],
+      })
+    },
+    async getStubSignature() {
+      return STUB_SIGNATURE
+    },
+    async signUserOperation({ chainId = CHAIN_ID, ...userOperation }) {
+      const hash = getUserOperationHash({
+        chainId,
+        entryPointAddress: entryPoint09Address,
+        entryPointVersion: '0.9',
+        userOperation: { ...userOperation, sender: address } as Parameters<
+          typeof getUserOperationHash
+        >[0]['userOperation'],
+      })
+      return wrapSignature(await signHash(hash))
+    },
+    async signMessage() {
+      throw new Error('Sign messages with the wallet client, not the smart account.')
+    },
+    async signTypedData() {
+      throw new Error('Sign typed data with the wallet client, not the smart account.')
+    },
+  })
+}
+
+export type SponsoredSender = ReturnType<typeof createSponsoredSender>
+
+export function createSponsoredSender({
+  account,
+  client,
+  publishableKey,
+  feeSponsorshipId,
+}: {
+  account: SmartAccount
+  client: PublicClient
+  publishableKey: string
+  feeSponsorshipId: string
+}) {
+  const transport = http(`https://api.openfort.io/rpc/${CHAIN_ID}`, {
+    fetchOptions: { headers: { Authorization: `Bearer ${publishableKey}` } },
+    timeout: 60_000,
+  })
+
+  const bundlerClient = createBundlerClient({
+    account,
+    chain: CHAIN,
+    client,
+    paymaster: createPaymasterClient({ transport }),
+    paymasterContext: { policyId: feeSponsorshipId },
+    transport,
+  })
+
+  return {
+    account,
+    /**
+     * Send one or more calls as a single sponsored UserOperation, attaching the
+     * EIP-7702 authorization the first time (before that the account has no code).
+     */
+    async send(calls: Call[], authorization?: unknown): Promise<Hex> {
+      // The bundler's floor sits above the chain's own suggestion, and the
+      // `pimlico_getUserOperationGasPrice` it points at isn't proxied. Overshoot.
+      const fees = await client.estimateFeesPerGas()
+      const maxPriorityFeePerGas = fees.maxPriorityFeePerGas * 20n
+      const maxFeePerGas = fees.maxFeePerGas * 2n + maxPriorityFeePerGas
+
+      const hash = await bundlerClient.sendUserOperation({
+        calls,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        ...(authorization ? { authorization } : {}),
+      } as Parameters<typeof bundlerClient.sendUserOperation>[0])
+
+      const receipt = await bundlerClient.waitForUserOperationReceipt({ hash })
+      if (!receipt.success) throw new Error(`UserOperation reverted: ${hash}`)
+      return receipt.receipt.transactionHash
+    },
+  }
+}
+
+/** Encode a contract call into the `{ to, data }` shape `send` batches. */
+export function toCall({
+  address,
+  abi,
+  functionName,
+  args,
+}: {
+  address: Address
+  // biome-ignore lint/suspicious/noExplicitAny: viem's ABI generics don't survive this indirection
+  abi: any
+  functionName: string
+  // biome-ignore lint/suspicious/noExplicitAny: same
+  args?: any
+}): Call {
+  return { to: address, value: 0n, data: encodeFunctionData({ abi, functionName, args }) }
+}

--- a/zama-confidential-yield/src/openfort/useSponsoredSender.ts
+++ b/zama-confidential-yield/src/openfort/useSponsoredSender.ts
@@ -1,0 +1,68 @@
+import { use7702Authorization, useOpenfort } from '@openfort/react'
+import { useCallback, useRef } from 'react'
+import type { Address, Hex, PublicClient } from 'viem'
+import { CHAIN_ID } from '../contracts/addresses'
+import {
+  type Call,
+  caliburImplementation,
+  createSponsoredSender,
+  type SponsoredSender,
+  toCaliburSmartAccount,
+} from './calibur'
+import { FEE_SPONSORSHIP_ID } from './Providers'
+
+/**
+ * Returns `send(calls)`, which submits the calls as one sponsored UserOperation.
+ *
+ * The EIP-7702 authorization is attached only while the account still has no
+ * code on-chain; after the first operation the delegation is installed and every
+ * later one skips it. Openfort's own SDK checks the same thing, so its native
+ * send path starts working from that point too.
+ */
+export function useSponsoredSender(publicClient: PublicClient | undefined, address?: Address) {
+  const { client } = useOpenfort()
+  const { signAuthorization } = use7702Authorization()
+  const senderRef = useRef<SponsoredSender | null>(null)
+
+  return useCallback(
+    async (calls: Call[]): Promise<Hex> => {
+      if (!publicClient || !address) throw new Error('Wallet is not connected yet.')
+      if (!FEE_SPONSORSHIP_ID) {
+        throw new Error('VITE_OPENFORT_FEE_SPONSORSHIP_ID is required to sponsor transactions.')
+      }
+
+      if (!senderRef.current) {
+        const account = await toCaliburSmartAccount({
+          client: publicClient,
+          address,
+          // Calibur's root key verifies a raw ECDSA signature over the userOpHash,
+          // so sign the digest itself — no EIP-191 prefix, no re-hashing.
+          signHash: (hash) =>
+            client.embeddedWallet.signMessage(hash, {
+              hashMessage: false,
+              arrayifyMessage: false,
+            }) as Promise<Hex>,
+        })
+        senderRef.current = createSponsoredSender({
+          account,
+          client: publicClient,
+          publishableKey: import.meta.env.VITE_OPENFORT_PUBLISHABLE_KEY,
+          feeSponsorshipId: FEE_SPONSORSHIP_ID,
+        })
+      }
+
+      const code = await publicClient.getCode({ address })
+      if (code && code !== '0x') return senderRef.current.send(calls)
+
+      const nonce = await publicClient.getTransactionCount({ address })
+      const result = await signAuthorization({
+        contractAddress: caliburImplementation(),
+        chainId: CHAIN_ID,
+        nonce,
+      })
+      if (result.status === 'error') throw new Error(result.error.shortMessage)
+      return senderRef.current.send(calls, result.authorization)
+    },
+    [client, publicClient, address, signAuthorization]
+  )
+}

--- a/zama-confidential-yield/src/openfort/wagmi.ts
+++ b/zama-confidential-yield/src/openfort/wagmi.ts
@@ -1,18 +1,17 @@
 import { getDefaultConfig } from '@openfort/react/wagmi'
 import { createConfig, http } from 'wagmi'
-import { CHAIN } from '../contracts/addresses'
+import { CHAIN, RPC_URL } from '../contracts/addresses'
 
-const RPC_URL = import.meta.env.VITE_RPC_URL
-
+/**
+ * `getDefaultConfig` registers Openfort's embedded-wallet connector, which is the
+ * only connector this app uses — `OpenfortWagmiBridge` connects it after the
+ * wallet is unlocked, and every read/write below goes through wagmi's viem
+ * clients. No WalletConnect project id: there is no connector picker to show it in.
+ */
 export const wagmiConfig = createConfig(
   getDefaultConfig({
     appName: 'Openfort · Confidential USDC',
     chains: [CHAIN],
-    walletConnectProjectId: import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID,
-    transports: {
-      // Falls back to the chain's default RPC if VITE_RPC_URL is unset, but the
-      // Zama relayer SDK is flaky on public RPCs — set your own.
-      [CHAIN.id]: http(RPC_URL),
-    },
+    transports: { [CHAIN.id]: http(RPC_URL) },
   })
 )

--- a/zama-confidential-yield/src/screens/Wallets.tsx
+++ b/zama-confidential-yield/src/screens/Wallets.tsx
@@ -1,7 +1,6 @@
 import { RecoveryMethod, useUser } from '@openfort/react'
 import { useEthereumEmbeddedWallet } from '@openfort/react/ethereum'
 import { useMemo, useState } from 'react'
-import { useAccount } from 'wagmi'
 import { fontStack, ghostBtn, monoStack, primaryBtn } from '../components/styles'
 import { ACCOUNT_TYPE } from '../openfort/Providers'
 
@@ -20,29 +19,30 @@ export function Wallets() {
   const isConnecting = embedded.isConnecting
   const walletError = embedded.status === 'error' ? embedded.error : null
   const { user, isAuthenticated } = useUser()
-  const { isConnected } = useAccount()
   const [error, setError] = useState<string | null>(null)
 
   if (!activeWallet && isConnecting) return <p style={muted}>Recovering wallet with passkey…</p>
   if (embedded.status === 'fetching-wallets' || (!user && isAuthenticated))
     return <p style={muted}>Loading wallets…</p>
 
+  // Embedded-wallet actions resolve with `{ error }` instead of rejecting, so a
+  // declined passkey prompt lands here rather than in a catch block.
   const create = async () => {
     setError(null)
-    try {
-      await embedded.create({ accountType: ACCOUNT_TYPE, recoveryMethod: RecoveryMethod.PASSKEY })
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Wallet creation failed')
-    }
+    const { error: failure } = await embedded.create({
+      accountType: ACCOUNT_TYPE,
+      recoveryMethod: RecoveryMethod.PASSKEY,
+    })
+    if (failure) setError(failure.shortMessage)
   }
 
   const recover = async (wallet: WalletEntry) => {
     setError(null)
-    try {
-      await embedded.setActive({ address: wallet.address, recoveryMethod: RecoveryMethod.PASSKEY })
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Recovery failed')
-    }
+    const { error: failure } = await embedded.setActive({
+      address: wallet.address,
+      recoveryMethod: RecoveryMethod.PASSKEY,
+    })
+    if (failure) setError(failure.shortMessage)
   }
 
   const createBtn = (
@@ -70,51 +70,47 @@ export function Wallets() {
     )
   }
 
-  if (!isConnected || activeWallet?.accountType !== ACCOUNT_TYPE) {
-    return (
-      <div style={col}>
-        <h1 style={heading}>Unlock wallet</h1>
-        <p style={body}>Recover your wallet with its passkey.</p>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {usable.map((wallet) => (
-            <div key={wallet.id + wallet.address} style={row}>
-              <div>
-                <p
-                  style={{ margin: 0, fontWeight: 600, fontFamily: monoStack, fontSize: '0.9rem' }}
-                >
-                  {truncate(wallet.address)}
-                </p>
-                <p
-                  style={{
-                    margin: '4px 0 0',
-                    fontSize: '0.74rem',
-                    color: 'var(--pd-ink-500)',
-                    fontFamily: fontStack,
-                  }}
-                >
-                  Passkey-secured
-                </p>
-              </div>
-              <button
-                type="button"
-                disabled={isConnecting}
-                onClick={() => recover(wallet)}
-                style={{ ...primaryBtn, fontSize: '0.85rem', opacity: isConnecting ? 0.6 : 1 }}
+  // App routes here only while no delegated wallet is connected, so this is the
+  // unlock list — the connected case never reaches this component.
+  return (
+    <div style={col}>
+      <h1 style={heading}>Unlock wallet</h1>
+      <p style={body}>Recover your wallet with its passkey.</p>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {usable.map((wallet) => (
+          <div key={wallet.id + wallet.address} style={row}>
+            <div>
+              <p style={{ margin: 0, fontWeight: 600, fontFamily: monoStack, fontSize: '0.9rem' }}>
+                {truncate(wallet.address)}
+              </p>
+              <p
+                style={{
+                  margin: '4px 0 0',
+                  fontSize: '0.74rem',
+                  color: 'var(--pd-ink-500)',
+                  fontFamily: fontStack,
+                }}
               >
-                {wallet.isConnecting ? 'Unlocking…' : 'Unlock'}
-              </button>
+                Passkey-secured
+              </p>
             </div>
-          ))}
-        </div>
-        {(error || walletError) && <p style={errText}>{error || walletError}</p>}
-        <button type="button" disabled={isCreating} onClick={create} style={ghostBtn}>
-          Create a new wallet instead
-        </button>
+            <button
+              type="button"
+              disabled={isConnecting}
+              onClick={() => recover(wallet)}
+              style={{ ...primaryBtn, fontSize: '0.85rem', opacity: isConnecting ? 0.6 : 1 }}
+            >
+              {wallet.isConnecting ? 'Unlocking…' : 'Unlock'}
+            </button>
+          </div>
+        ))}
       </div>
-    )
-  }
-
-  return null
+      {(error || walletError) && <p style={errText}>{error || walletError}</p>}
+      <button type="button" disabled={isCreating} onClick={create} style={ghostBtn}>
+        Create a new wallet instead
+      </button>
+    </div>
+  )
 }
 
 const col = {

--- a/zama-confidential-yield/src/zama/confidential.ts
+++ b/zama-confidential-yield/src/zama/confidential.ts
@@ -1,17 +1,12 @@
-import { decodeEventLog, type EIP1193Provider, type Log, maxUint256, parseUnits } from 'viem'
+import { decodeEventLog, type Log, maxUint256, parseUnits } from 'viem'
 import { batcherAbi, confidentialWrapperAbi, erc20Abi, erc4626Abi } from '../contracts/abis'
 import { ADDRESSES, DECIMALS } from '../contracts/addresses'
-import { makeRuntime, type Runtime } from './sdk'
+import type { Runtime } from './sdk'
 
 type Hex = `0x${string}`
 
 /** csteakcUSDC wraps the 18-decimal clear vault share as 6 decimals → rate 10^12. */
 const SHARE_RATE = 10n ** 12n
-
-export type { Runtime }
-export function makeClients(provider: EIP1193Provider, account: Hex): Runtime {
-  return makeRuntime(provider, account)
-}
 
 // ── perf audit: log how long each phase takes, split by side ──────────────────
 // [perf] openfort.send:* = userOp submit + paymaster sponsorship (Openfort/4337)

--- a/zama-confidential-yield/src/zama/confidential.ts
+++ b/zama-confidential-yield/src/zama/confidential.ts
@@ -121,7 +121,7 @@ function findUnwrapRequestId(logs: readonly Log[]): Hex {
 export function mintTestUsdc(rt: Runtime, human = '100') {
   const amount = parseUnits(human, DECIMALS)
   return exec(rt, 'mint', () =>
-    rt.walletClient.writeContract({
+    rt.write({
       address: ADDRESSES.usdc,
       abi: erc20Abi,
       functionName: 'mint',
@@ -140,25 +140,28 @@ export async function shield(rt: Runtime, human: string) {
     functionName: 'allowance',
     args: [rt.account, ADDRESSES.cusdc],
   })
-  // Approve max once so repeat shields skip the extra sponsored userOp.
+  const wrap = {
+    address: ADDRESSES.cusdc,
+    abi: confidentialWrapperAbi,
+    functionName: 'wrap',
+    args: [rt.account, amount],
+  }
+  // Approve max once. A UserOperation batches atomically, so a first-time shield
+  // is approve+wrap in a single sponsored operation rather than two.
   if (allowance < amount) {
-    await exec(rt, 'approve', () =>
-      rt.walletClient.writeContract({
-        address: ADDRESSES.usdc,
-        abi: erc20Abi,
-        functionName: 'approve',
-        args: [ADDRESSES.cusdc, maxUint256],
-      })
+    return exec(rt, 'approve+wrap', () =>
+      rt.writeBatch([
+        {
+          address: ADDRESSES.usdc,
+          abi: erc20Abi,
+          functionName: 'approve',
+          args: [ADDRESSES.cusdc, maxUint256],
+        },
+        wrap,
+      ])
     )
   }
-  return exec(rt, 'wrap', () =>
-    rt.walletClient.writeContract({
-      address: ADDRESSES.cusdc,
-      abi: confidentialWrapperAbi,
-      functionName: 'wrap',
-      args: [rt.account, amount],
-    })
-  )
+  return exec(rt, 'wrap', () => rt.write(wrap))
 }
 
 // ── unshield: cUSDC → USDC (encrypt → unwrap → public-decrypt → finalize) ──────
@@ -167,7 +170,7 @@ export async function unshield(rt: Runtime, human: string) {
   const units = parseUnits(human, DECIMALS)
   const { handle, inputProof } = await encrypt(rt, ADDRESSES.cusdc, units)
   const unwrapHash = await exec(rt, 'unwrap', () =>
-    rt.walletClient.writeContract({
+    rt.write({
       address: ADDRESSES.cusdc,
       abi: confidentialWrapperAbi,
       functionName: 'unwrap',
@@ -184,7 +187,7 @@ export async function unshield(rt: Runtime, human: string) {
   const cleartext = typeof raw === 'bigint' ? raw : BigInt(raw ?? 0)
 
   return exec(rt, 'finalizeUnwrap', () =>
-    rt.walletClient.writeContract({
+    rt.write({
       address: ADDRESSES.cusdc,
       abi: confidentialWrapperAbi,
       functionName: 'finalizeUnwrap',
@@ -200,7 +203,7 @@ export async function vaultDeposit(rt: Runtime, human: string): Promise<bigint> 
   const units = parseUnits(human, DECIMALS)
   const { handle, inputProof } = await encrypt(rt, ADDRESSES.cusdc, units)
   await exec(rt, 'deposit', () =>
-    rt.walletClient.writeContract({
+    rt.write({
       address: ADDRESSES.cusdc,
       abi: confidentialWrapperAbi,
       functionName: 'confidentialTransferAndCall',
@@ -215,7 +218,7 @@ export async function vaultRedeem(rt: Runtime, human: string): Promise<bigint> {
   const units = parseUnits(human, DECIMALS)
   const { handle, inputProof } = await encrypt(rt, ADDRESSES.confidentialShare, units)
   await exec(rt, 'redeem', () =>
-    rt.walletClient.writeContract({
+    rt.write({
       address: ADDRESSES.confidentialShare,
       abi: confidentialWrapperAbi,
       functionName: 'confidentialTransferAndCall',
@@ -250,7 +253,7 @@ export async function readBatchPosition(
 /** Claim your output once a batch is Finalized (state 2). */
 export function claimBatch(rt: Runtime, kind: BatchKind, batchId: bigint) {
   return exec(rt, `claim:${kind}`, () =>
-    rt.walletClient.writeContract({
+    rt.write({
       address: batcherAddress(kind),
       abi: batcherAbi,
       functionName: 'claim',

--- a/zama-confidential-yield/src/zama/sdk.ts
+++ b/zama-confidential-yield/src/zama/sdk.ts
@@ -7,37 +7,27 @@ import {
 } from '@zama-fhe/sdk'
 import { createConfig } from '@zama-fhe/sdk/viem'
 import { web } from '@zama-fhe/sdk/web'
-import { createPublicClient, createWalletClient, custom, type EIP1193Provider, http } from 'viem'
-import { CHAIN, NETWORK } from '../contracts/addresses'
+import type { Account, Chain, PublicClient, Transport, WalletClient } from 'viem'
+import { NETWORK, RPC_URL } from '../contracts/addresses'
 
-type Hex = `0x${string}`
+/** The account-bound wallet client wagmi hands back for the embedded wallet. */
+export type EmbeddedWalletClient = WalletClient<Transport, Chain, Account>
 
-/** Precise inferred client types (chain + account bound) so `writeContract` needs no extra args. */
 export type Runtime = ReturnType<typeof makeRuntime>
 
 /**
- * Wire the Zama SDK to viem clients backed by the Openfort embedded wallet, for
- * the active network (Sepolia by default, mainnet when `VITE_NETWORK=mainnet`).
+ * Wire the Zama SDK to the viem clients wagmi already owns.
  *
- * The same EIP-1193 `provider` drives both on-chain writes (walletClient) and
- * the EIP-712 decryption permit `sdk.decryption.decryptValues` asks for — so the
- * Openfort wallet is the single signer. `web()` runs the FHE WASM in a Web
- * Worker; `indexedDBStorage` persists the decryption permit across reloads.
+ * `usePublicClient()` and `useWalletClient()` come from the same wagmi config
+ * the Openfort embedded connector is registered in, so the wallet client signs
+ * with the embedded wallet without this app ever touching an EIP-1193 provider:
+ * on-chain writes and the EIP-712 decryption permit `sdk.decryption.decryptValues`
+ * asks for both go through it. `web()` runs the FHE WASM in a Web Worker;
+ * `indexedDBStorage` persists the decryption permit across reloads.
  */
-export function makeRuntime(provider: EIP1193Provider, account: Hex) {
-  const rpc = import.meta.env.VITE_RPC_URL
-  const publicClient = createPublicClient({
-    chain: CHAIN,
-    transport: rpc ? http(rpc) : custom(provider),
-  })
-  const walletClient = createWalletClient({
-    account,
-    chain: CHAIN,
-    transport: custom(provider),
-  })
-
+export function makeRuntime(publicClient: PublicClient, walletClient: EmbeddedWalletClient) {
   const preset = NETWORK === 'mainnet' ? zamaMainnet : zamaSepolia
-  const fheChain: FheChain = rpc ? { ...preset, network: rpc } : preset
+  const fheChain: FheChain = { ...preset, network: RPC_URL }
   const config = createConfig({
     chains: [fheChain],
     relayers: { [fheChain.id]: web() },
@@ -46,5 +36,10 @@ export function makeRuntime(provider: EIP1193Provider, account: Hex) {
     storage: indexedDBStorage,
   })
 
-  return { account, sdk: new ZamaSDK(config), publicClient, walletClient }
+  return {
+    account: walletClient.account.address,
+    sdk: new ZamaSDK(config),
+    publicClient,
+    walletClient,
+  }
 }

--- a/zama-confidential-yield/src/zama/sdk.ts
+++ b/zama-confidential-yield/src/zama/sdk.ts
@@ -7,13 +7,17 @@ import {
 } from '@zama-fhe/sdk'
 import { createConfig } from '@zama-fhe/sdk/viem'
 import { web } from '@zama-fhe/sdk/web'
-import type { Account, Chain, PublicClient, Transport, WalletClient } from 'viem'
+import type { Account, Chain, Hex, PublicClient, Transport, WalletClient } from 'viem'
 import { NETWORK, RPC_URL } from '../contracts/addresses'
+import { type Call, toCall } from '../openfort/calibur'
 
 /** The account-bound wallet client wagmi hands back for the embedded wallet. */
 export type EmbeddedWalletClient = WalletClient<Transport, Chain, Account>
 
 export type Runtime = ReturnType<typeof makeRuntime>
+
+/** Submits a batch of calls as one sponsored UserOperation, resolving the tx hash. */
+export type SendCalls = (calls: Call[]) => Promise<Hex>
 
 /**
  * Wire the Zama SDK to the viem clients wagmi already owns.
@@ -24,8 +28,15 @@ export type Runtime = ReturnType<typeof makeRuntime>
  * on-chain writes and the EIP-712 decryption permit `sdk.decryption.decryptValues`
  * asks for both go through it. `web()` runs the FHE WASM in a Web Worker;
  * `indexedDBStorage` persists the decryption permit across reloads.
+ *
+ * Writes do NOT go through the wallet client: they are submitted as sponsored
+ * UserOperations by `sendCalls`. See `openfort/calibur.ts` for why.
  */
-export function makeRuntime(publicClient: PublicClient, walletClient: EmbeddedWalletClient) {
+export function makeRuntime(
+  publicClient: PublicClient,
+  walletClient: EmbeddedWalletClient,
+  sendCalls: SendCalls
+) {
   const preset = NETWORK === 'mainnet' ? zamaMainnet : zamaSepolia
   const fheChain: FheChain = { ...preset, network: RPC_URL }
   const config = createConfig({
@@ -41,5 +52,9 @@ export function makeRuntime(publicClient: PublicClient, walletClient: EmbeddedWa
     sdk: new ZamaSDK(config),
     publicClient,
     walletClient,
+    /** One contract call, one sponsored UserOperation. */
+    write: (call: Parameters<typeof toCall>[0]) => sendCalls([toCall(call)]),
+    /** Several calls atomically in a single sponsored UserOperation. */
+    writeBatch: (calls: Parameters<typeof toCall>[0][]) => sendCalls(calls.map(toCall)),
   }
 }

--- a/zama-confidential-yield/vite.config.ts
+++ b/zama-confidential-yield/vite.config.ts
@@ -4,11 +4,6 @@ import { defineConfig } from 'vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  // The Zama relayer SDK ships WASM; excluding it from dep pre-bundling avoids
-  // the esbuild "wrong relayer url / __wbindgen_malloc" class of init failures.
-  optimizeDeps: {
-    exclude: ['@zama-fhe/relayer-sdk'],
-  },
   // Dedicated port so it doesn't collide with other recipe dev servers.
   server: { port: 5182, strictPort: true },
 })


### PR DESCRIPTION
Rebuilds how the Zama recipe uses Openfort, and fixes gas sponsorship on it.

## Headless SDK v2

The recipe was the last one on `@openfort/react` 1.6.0 while its siblings moved to 2.x. It now runs 2.1.0, rebuilt on the patterns in `examples/quickstarts/headless`:

- No `uiConfig` — nothing opens the modal, the phone UI is the app's own.
- `connectOnLogin: false`, so `screens/Wallets` is the only caller of `create()` / `setActive()` and the passkey prompt never fires behind the login. The default also keeps `useOpenfort().isLoading` true when accounts exist but none is active, which parked the unlock screen on a spinner.
- Wallet actions resolve `{ error }` in v2 instead of rejecting, so the `try`/`catch` around them caught nothing — a declined passkey showed no error at all.
- `getDefaultConfig` sets wagmi's `ssr: true`, so the first render reports `reconnecting` with `isConnected` false; the wallet screen now gates on that instead of flashing.
- Zama's viem clients come from `usePublicClient` / `useWalletClient` rather than casting an EIP-1193 provider off the wallet hook.
- One `RPC_URL`, read by wagmi's transport, `walletConfig.ethereum.rpcUrls` and the Zama FHE chain.

## Sponsored UserOperations

A Delegated Account's first write must carry an EIP-7702 authorization. Building that server-side takes ~30s while the edge cuts the request at 15s, so the account never delegates and every sponsored write fails as `Transaction creation failed … Details: Network Error` — with `axios-retry` turning one click into four intents 15s apart, all parked at `sign_with_wallet`.

Writes now go out as UserOperations through Openfort's bundler and paymaster (`api.openfort.io/rpc/<chainId>`), built client-side in ~1.4s, with the delegation riding along in the same operation. It delegates to **Calibur**, the implementation Openfort uses natively, so once the first operation lands the SDK's own delegation check passes and its normal send path works again.

Four details in `src/openfort/calibur.ts`, none of them currently documented:

| | |
| --- | --- |
| EntryPoint | **v0.9**, not the v0.7/v0.8 Calibur's README states. It selects paymaster `0x9999fEe9…`; v0.8 silently selects a different one |
| callData | `executeUserOp` selector ++ `abi.encode(BatchedCall{Call[], bool revertOnFailure})` |
| signature | `abi.encode(ROOT_KEY_HASH, signature, hookData)`; a bare 65-byte signature reverts `SliceOutOfBounds()` |
| gas | the bundler's floor sits above the chain's estimate, and the `pimlico_getUserOperationGasPrice` it points at is not proxied |

Verified on Sepolia from a never-funded key: 1.36s, `success: true`, delegation installed, balance still zero.

A first-time shield is now approve+wrap in a single operation, since a UserOperation is atomic.

## UI

The dashboard splits into Balance and Earn behind a floating tab bar pinned to the phone's bottom edge, with a count badge on Earn so pending batches aren't hidden by the tab. Both sections lead with a public/shielded balance pair.

## Checks

`tsc -b`, `biome check` and `vite build` clean. Flows exercised live on Sepolia against test keys.