### PR TITLE
zama-confidential-yield: fix signing, gas floor and batch tracking

### DIFF
--- a/zama-confidential-yield/src/App.tsx
+++ b/zama-confidential-yield/src/App.tsx
@@ -19,7 +19,7 @@ type Step = 'loading' | 'auth' | 'wallet' | 'dashboard'
 function useStep(): Step {
   const { isLoading } = useOpenfort()
   const { isAuthenticated } = useUser()
-  const { isConnected, status } = useAccount()
+  const { address, isConnected, status } = useAccount()
   const wallet = useEthereumEmbeddedWallet()
   const busy = wallet.status === 'fetching-wallets' || wallet.isConnecting
 
@@ -31,6 +31,14 @@ function useStep(): Step {
   // unlock screen over a wallet that is one tick from connecting.
   if (status === 'reconnecting') return 'loading'
   if (!isConnected || wallet.activeWallet?.accountType !== ACCOUNT_TYPE) return 'wallet'
+  // The embedded provider pins itself to one address and rejects every request
+  // once the active wallet moves on ("The active wallet changed before the
+  // operation could run"). Send them back to pick a wallet rather than letting
+  // that surface from inside a decryption.
+  const signerAddress = wallet.status === 'connected' ? wallet.address : undefined
+  if (address && signerAddress && address.toLowerCase() !== signerAddress.toLowerCase()) {
+    return 'wallet'
+  }
   return 'dashboard'
 }
 

--- a/zama-confidential-yield/src/App.tsx
+++ b/zama-confidential-yield/src/App.tsx
@@ -19,7 +19,7 @@ type Step = 'loading' | 'auth' | 'wallet' | 'dashboard'
 function useStep(): Step {
   const { isLoading } = useOpenfort()
   const { isAuthenticated } = useUser()
-  const { address, isConnected, status } = useAccount()
+  const { isConnected, status } = useAccount()
   const wallet = useEthereumEmbeddedWallet()
   const busy = wallet.status === 'fetching-wallets' || wallet.isConnecting
 
@@ -31,14 +31,6 @@ function useStep(): Step {
   // unlock screen over a wallet that is one tick from connecting.
   if (status === 'reconnecting') return 'loading'
   if (!isConnected || wallet.activeWallet?.accountType !== ACCOUNT_TYPE) return 'wallet'
-  // The embedded provider pins itself to one address and rejects every request
-  // once the active wallet moves on ("The active wallet changed before the
-  // operation could run"). Send them back to pick a wallet rather than letting
-  // that surface from inside a decryption.
-  const signerAddress = wallet.status === 'connected' ? wallet.address : undefined
-  if (address && signerAddress && address.toLowerCase() !== signerAddress.toLowerCase()) {
-    return 'wallet'
-  }
   return 'dashboard'
 }
 

--- a/zama-confidential-yield/src/components/BatchStatus.tsx
+++ b/zama-confidential-yield/src/components/BatchStatus.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, useState } from 'react'
+import { type CSSProperties, useEffect, useState } from 'react'
 import { formatUnits } from 'viem'
 import { DECIMALS } from '../contracts/addresses'
 import {
@@ -6,6 +6,7 @@ import {
   batchInfo,
   claimBatch,
   decryptHandles,
+  isBatchClaimable,
   readBatchPosition,
 } from '../zama/confidential'
 import type { Runtime } from '../zama/sdk'
@@ -16,7 +17,7 @@ type Batch = { kind: BatchKind; batchId: bigint; state: number }
 const STEPS = [
   { title: 'Open', body: 'Your deposit is pooling with others in the current batch.' },
   { title: 'Dispatched', body: 'The batch closed and was sent to settle off-chain.' },
-  { title: 'Finalized', body: 'Settled — claim to receive your confidential shares.' },
+  { title: 'Ready to claim', body: 'Settled — claim to receive your confidential shares.' },
 ] as const
 
 /** Full in-phone "page" showing one batch's lifecycle + claim. */
@@ -36,8 +37,20 @@ export function BatchStatus({
   const [busy, setBusy] = useState<null | 'refresh' | 'claim' | 'reveal'>(null)
   const [pending, setPending] = useState<bigint | null>(null)
   const [msg, setMsg] = useState<string | null>(null)
-  const ready = batch.state >= 2
+  const ready = isBatchClaimable(batch.state)
   const unit = batch.kind === 'deposit' ? 'cUSDC' : 'shares'
+
+  // The operator settles off-chain with no event to watch, so poll while this
+  // page is open rather than making the user tap Refresh to find out.
+  useEffect(() => {
+    if (ready) return
+    const id = setInterval(() => {
+      batchInfo(rt, batch.kind, batch.batchId)
+        .then((info) => onState(info.state))
+        .catch(() => {})
+    }, 15_000)
+    return () => clearInterval(id)
+  }, [rt, batch.kind, batch.batchId, ready, onState])
 
   const refresh = async () => {
     setBusy('refresh')

--- a/zama-confidential-yield/src/components/Dashboard.tsx
+++ b/zama-confidential-yield/src/components/Dashboard.tsx
@@ -50,7 +50,7 @@ export function Dashboard() {
   const account = walletClient?.account.address
   // Writes go out as sponsored UserOperations through Openfort's bundler, not
   // through the wallet client — see openfort/calibur.ts.
-  const send = useSponsoredSender(publicClient, account)
+  const send = useSponsoredSender(publicClient)
   const rt = useMemo<Runtime | null>(
     () => (publicClient && walletClient ? makeRuntime(publicClient, walletClient, send) : null),
     [publicClient, walletClient, send]

--- a/zama-confidential-yield/src/components/Dashboard.tsx
+++ b/zama-confidential-yield/src/components/Dashboard.tsx
@@ -1,8 +1,9 @@
 import { useSignOut } from '@openfort/react'
 import { type CSSProperties, useCallback, useEffect, useMemo, useState } from 'react'
 import { formatUnits } from 'viem'
-import { usePublicClient, useWalletClient } from 'wagmi'
+import { usePublicClient } from 'wagmi'
 import { ADDRESSES, DECIMALS, FAUCET_URL, GAS_FAUCET_URL, NETWORK } from '../contracts/addresses'
+import { useEmbeddedWalletClient } from '../openfort/useEmbeddedWalletClient'
 import { useSponsoredSender } from '../openfort/useSponsoredSender'
 import {
   type BatchKind,
@@ -46,7 +47,9 @@ export function Dashboard() {
   // the wallet client is the embedded wallet and the public client reads from
   // the same RPC. Zama's SDK takes plain viem clients — no provider plumbing.
   const publicClient = usePublicClient()
-  const { data: walletClient } = useWalletClient()
+  // The wallet client rides the active wallet's own provider, so the address it
+  // is pinned to always matches the one operations are built for.
+  const walletClient = useEmbeddedWalletClient()
   const account = walletClient?.account.address
   // Writes go out as sponsored UserOperations through Openfort's bundler, not
   // through the wallet client — see openfort/calibur.ts.

--- a/zama-confidential-yield/src/components/Dashboard.tsx
+++ b/zama-confidential-yield/src/components/Dashboard.tsx
@@ -7,8 +7,11 @@ import { useEmbeddedWalletClient } from '../openfort/useEmbeddedWalletClient'
 import { useSponsoredSender } from '../openfort/useSponsoredSender'
 import {
   type BatchKind,
+  batchInfo,
+  batchStateLabel,
   decryptHandles,
   type HandleRef,
+  isBatchClaimable,
   mintTestUsdc,
   readEncryptedHandle,
   readUsdcBalance,
@@ -33,7 +36,6 @@ const fmt = (v: bigint) =>
   })
 
 type Pending = { key: string; kind: BatchKind; batchId: bigint; state: number }
-const STATE_LABEL = ['Open', 'Dispatched', 'Ready'] as const
 
 const TABS = [
   { id: 'balance', icon: '💵', label: 'Balance' },
@@ -104,6 +106,34 @@ export function Dashboard() {
     const id = setInterval(() => void refreshUsdc(), 10_000)
     return () => clearInterval(id)
   }, [refreshUsdc])
+
+  // An off-chain operator settles each batch, so the only way to notice is to
+  // ask. Without this a finished batch sits there reading "Open" until tapped.
+  // Keyed on the batch ids, not on `pending` itself, or writing a state back
+  // would restart the interval and poll in a loop.
+  const pendingKey = pending.map((b) => `${b.kind}:${b.batchId}`).join(',')
+  useEffect(() => {
+    if (!rt || !pendingKey) return
+    const batches = pendingKey.split(',').map((entry) => {
+      const [kind, id] = entry.split(':')
+      return { kind: kind as BatchKind, batchId: BigInt(id as string) }
+    })
+    const poll = async () => {
+      const states = await Promise.all(
+        batches.map((b) => batchInfo(rt, b.kind, b.batchId).catch(() => null))
+      )
+      setPending((rows) =>
+        rows.map((row) => {
+          const i = batches.findIndex((b) => b.kind === row.kind && b.batchId === row.batchId)
+          const state = i === -1 ? null : states[i]?.state
+          return state === undefined || state === null ? row : { ...row, state }
+        })
+      )
+    }
+    void poll()
+    const id = setInterval(() => void poll(), 30_000)
+    return () => clearInterval(id)
+  }, [rt, pendingKey])
 
   const getUsdc = async () => {
     if (!rt) return
@@ -407,11 +437,13 @@ export function Dashboard() {
                           margin: '2px 0 0',
                           fontFamily: fontStack,
                           fontSize: '0.72rem',
-                          color: b.state >= 2 ? 'var(--pd-success)' : 'var(--pd-ink-400)',
+                          color: isBatchClaimable(b.state)
+                            ? 'var(--pd-success)'
+                            : 'var(--pd-ink-400)',
                         }}
                       >
-                        {STATE_LABEL[b.state] ?? 'Open'}
-                        {b.state >= 2 ? ' · tap to claim' : ' · tap for status'}
+                        {batchStateLabel(b.state)}
+                        {isBatchClaimable(b.state) ? ' · tap to claim' : ' · tap for status'}
                       </p>
                     </div>
                     <span style={{ color: 'var(--pd-ink-400)', fontSize: '1.2rem' }}>›</span>

--- a/zama-confidential-yield/src/openfort/calibur.ts
+++ b/zama-confidential-yield/src/openfort/calibur.ts
@@ -162,6 +162,16 @@ export async function toCaliburSmartAccount({
   })
 }
 
+/** `maxPriorityFeePerGas must be at least 20501760 (current …)` → the figure and the field. */
+function requiredFee(error: unknown): { field: string; value: bigint } | null {
+  const message = error instanceof Error ? `${error.message}\n${error.cause ?? ''}` : String(error)
+  const match = message.match(/(maxPriorityFeePerGas|maxFeePerGas) must be at least (\d+)/)
+  return match?.[1] && match[2] ? { field: match[1], value: BigInt(match[2]) } : null
+}
+
+/** The floor tracks the base fee, so it can move again before the retry lands. */
+const withHeadroom = (value: bigint) => (value * 13n) / 10n
+
 export type SponsoredSender = ReturnType<typeof createSponsoredSender>
 
 export function createSponsoredSender({
@@ -196,18 +206,35 @@ export function createSponsoredSender({
      * EIP-7702 authorization the first time (before that the account has no code).
      */
     async send(calls: Call[], authorization?: unknown): Promise<Hex> {
-      // The bundler's floor sits above the chain's own suggestion, and the
-      // `pimlico_getUserOperationGasPrice` it points at isn't proxied. Overshoot.
       const fees = await client.estimateFeesPerGas()
-      const maxPriorityFeePerGas = fees.maxPriorityFeePerGas * 20n
-      const maxFeePerGas = fees.maxFeePerGas * 2n + maxPriorityFeePerGas
+      let maxPriorityFeePerGas = fees.maxPriorityFeePerGas * 20n
+      let maxFeePerGas = fees.maxFeePerGas * 2n + maxPriorityFeePerGas
 
-      const hash = await bundlerClient.sendUserOperation({
-        calls,
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-        ...(authorization ? { authorization } : {}),
-      } as Parameters<typeof bundlerClient.sendUserOperation>[0])
+      // The bundler enforces a floor above the chain's own suggestion, moves it
+      // with the base fee, and points at a `pimlico_` method it doesn't proxy.
+      // It does name the figure it wants, so take it and retry — one round per
+      // field, plus headroom for the floor drifting between attempts.
+      let hash: Hex | undefined
+      for (let attempt = 0; attempt < 4 && !hash; attempt++) {
+        try {
+          hash = await bundlerClient.sendUserOperation({
+            calls,
+            maxFeePerGas,
+            maxPriorityFeePerGas,
+            ...(authorization ? { authorization } : {}),
+          } as Parameters<typeof bundlerClient.sendUserOperation>[0])
+        } catch (error) {
+          const required = requiredFee(error)
+          if (!required) throw error
+          if (required.field === 'maxPriorityFeePerGas') {
+            maxPriorityFeePerGas = withHeadroom(required.value)
+            if (maxFeePerGas < maxPriorityFeePerGas) maxFeePerGas = maxPriorityFeePerGas
+          } else {
+            maxFeePerGas = withHeadroom(required.value)
+          }
+        }
+      }
+      if (!hash) throw new Error('The bundler kept rejecting the gas price. Try again.')
 
       const receipt = await bundlerClient.waitForUserOperationReceipt({ hash })
       if (!receipt.success) throw new Error(`UserOperation reverted: ${hash}`)

--- a/zama-confidential-yield/src/openfort/useEmbeddedWalletClient.ts
+++ b/zama-confidential-yield/src/openfort/useEmbeddedWalletClient.ts
@@ -1,0 +1,54 @@
+import { useEthereumEmbeddedWallet } from '@openfort/react/ethereum'
+import { useEffect, useState } from 'react'
+import { createWalletClient, custom, type EIP1193Provider } from 'viem'
+import { CHAIN } from '../contracts/addresses'
+import type { EmbeddedWalletClient } from '../zama/sdk'
+
+/**
+ * A viem wallet client on the *active wallet's own* provider.
+ *
+ * Not `useWalletClient()` from wagmi: the embedded provider pins itself to the
+ * address it was built for and rejects every later request once the active
+ * wallet moves on, so a connector-held provider from earlier in the session
+ * fails with "The active wallet changed before the operation could run" —
+ * surfacing from inside whatever happened to need a signature. Asking the active
+ * wallet for its provider keeps the pin and the address we sign for together.
+ */
+export function useEmbeddedWalletClient(): EmbeddedWalletClient | null {
+  const wallet = useEthereumEmbeddedWallet()
+  const address = wallet.status === 'connected' ? wallet.address : undefined
+  const [client, setClient] = useState<EmbeddedWalletClient | null>(null)
+
+  useEffect(() => {
+    if (!address) {
+      setClient(null)
+      return
+    }
+    let cancelled = false
+    const activeWallet = wallet.activeWallet
+    if (!activeWallet) return
+
+    activeWallet
+      .getProvider()
+      .then((provider) => {
+        if (cancelled) return
+        setClient(
+          createWalletClient({
+            account: address,
+            chain: CHAIN,
+            transport: custom(provider as EIP1193Provider),
+          })
+        )
+      })
+      .catch(() => {
+        if (!cancelled) setClient(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+    // `activeWallet` is a fresh object every render; the address is what changes.
+  }, [address, wallet.activeWallet])
+
+  return client
+}

--- a/zama-confidential-yield/src/openfort/useSponsoredSender.ts
+++ b/zama-confidential-yield/src/openfort/useSponsoredSender.ts
@@ -1,6 +1,8 @@
 import { use7702Authorization, useOpenfort } from '@openfort/react'
+import { useEthereumEmbeddedWallet } from '@openfort/react/ethereum'
 import { useCallback, useRef } from 'react'
-import type { Address, Hex, PublicClient } from 'viem'
+import type { Hex, PublicClient } from 'viem'
+import { recoverAddress } from 'viem'
 import { CHAIN_ID } from '../contracts/addresses'
 import {
   type Call,
@@ -18,11 +20,19 @@ import { FEE_SPONSORSHIP_ID } from './Providers'
  * code on-chain; after the first operation the delegation is installed and every
  * later one skips it. Openfort's own SDK checks the same thing, so its native
  * send path starts working from that point too.
+ *
+ * The address comes from the embedded wallet rather than from wagmi, because it
+ * has to be the account the embedded signer will actually sign with. Sourcing it
+ * anywhere else lets `sender` and the signing key drift apart, which the
+ * EntryPoint reports only as the uninformative `AA24 signature error`.
  */
-export function useSponsoredSender(publicClient: PublicClient | undefined, address?: Address) {
+export function useSponsoredSender(publicClient: PublicClient | undefined) {
   const { client } = useOpenfort()
+  const wallet = useEthereumEmbeddedWallet()
   const { signAuthorization } = use7702Authorization()
-  const senderRef = useRef<SponsoredSender | null>(null)
+  const senderRef = useRef<{ address: Hex; sender: SponsoredSender } | null>(null)
+
+  const address = wallet.status === 'connected' ? wallet.address : undefined
 
   return useCallback(
     async (calls: Call[]): Promise<Hex> => {
@@ -31,28 +41,43 @@ export function useSponsoredSender(publicClient: PublicClient | undefined, addre
         throw new Error('VITE_OPENFORT_FEE_SPONSORSHIP_ID is required to sponsor transactions.')
       }
 
-      if (!senderRef.current) {
-        const account = await toCaliburSmartAccount({
-          client: publicClient,
-          address,
-          // Calibur's root key verifies a raw ECDSA signature over the userOpHash,
-          // so sign the digest itself — no EIP-191 prefix, no re-hashing.
-          signHash: (hash) =>
-            client.embeddedWallet.signMessage(hash, {
-              hashMessage: false,
-              arrayifyMessage: false,
-            }) as Promise<Hex>,
-        })
-        senderRef.current = createSponsoredSender({
-          account,
-          client: publicClient,
-          publishableKey: import.meta.env.VITE_OPENFORT_PUBLISHABLE_KEY,
-          feeSponsorshipId: FEE_SPONSORSHIP_ID,
-        })
+      const signHash = async (hash: Hex): Promise<Hex> => {
+        // Calibur's root key verifies a raw ECDSA signature over the userOpHash,
+        // so sign the digest itself — no EIP-191 prefix, no re-hashing.
+        const signature = (await client.embeddedWallet.signMessage(hash, {
+          hashMessage: false,
+          arrayifyMessage: false,
+        })) as Hex
+        // The signer uses whichever wallet is active now, while `sender` was
+        // fixed when the operation was built. If a wallet switch slipped in
+        // between, say so here rather than letting the bundler reject it.
+        const signer = await recoverAddress({ hash, signature })
+        if (signer.toLowerCase() !== address.toLowerCase()) {
+          throw new Error(
+            `Signed with ${signer} but the operation is for ${address}. The active wallet changed — reconnect and try again.`
+          )
+        }
+        return signature
       }
 
+      // Rebuild whenever the active wallet changes: a cached account keeps
+      // carrying the previous address as `sender`.
+      if (senderRef.current?.address !== address) {
+        const account = await toCaliburSmartAccount({ client: publicClient, address, signHash })
+        senderRef.current = {
+          address,
+          sender: createSponsoredSender({
+            account,
+            client: publicClient,
+            publishableKey: import.meta.env.VITE_OPENFORT_PUBLISHABLE_KEY,
+            feeSponsorshipId: FEE_SPONSORSHIP_ID,
+          }),
+        }
+      }
+      const { sender } = senderRef.current
+
       const code = await publicClient.getCode({ address })
-      if (code && code !== '0x') return senderRef.current.send(calls)
+      if (code && code !== '0x') return sender.send(calls)
 
       const nonce = await publicClient.getTransactionCount({ address })
       const result = await signAuthorization({
@@ -61,7 +86,7 @@ export function useSponsoredSender(publicClient: PublicClient | undefined, addre
         nonce,
       })
       if (result.status === 'error') throw new Error(result.error.shortMessage)
-      return senderRef.current.send(calls, result.authorization)
+      return sender.send(calls, result.authorization)
     },
     [client, publicClient, address, signAuthorization]
   )

--- a/zama-confidential-yield/src/zama/confidential.ts
+++ b/zama-confidential-yield/src/zama/confidential.ts
@@ -264,6 +264,22 @@ export function claimBatch(rt: Runtime, kind: BatchKind, batchId: bigint) {
 
 export type BatchInfo = { batchId: bigint; state: number }
 
+/**
+ * 0 and 1 are Open and Dispatched. Everything from 2 up is settled and
+ * claimable — the batcher returns 3 for most settled batches on Sepolia, so the
+ * "0=Open 1=Dispatched 2=Finalized" comment in the integration reference is not
+ * the whole enum. Don't label a state we haven't seen; say what it is.
+ */
+export function batchStateLabel(state: number): string {
+  if (state === 0) return 'Open'
+  if (state === 1) return 'Dispatched'
+  if (state >= 2) return 'Ready to claim'
+  return `State ${state}`
+}
+
+/** Settled far enough that `claim` will pay out. */
+export const isBatchClaimable = (state: number) => state >= 2
+
 /** 0=Open, 1=Dispatched, 2=Finalized. */
 export async function batchInfo(rt: Runtime, kind: BatchKind, batchId: bigint): Promise<BatchInfo> {
   const state = await rt.publicClient.readContract({


### PR DESCRIPTION
Three follow-ups to #57, from exercising the recipe live on Sepolia.

## Sender and signing key drifting apart

Reveal failed with `Credential signing failed … The active wallet changed before the operation could run`, and unshield with `AA24 signature error`. Same cause: the embedded provider pins itself to the address it was built for — `serializeEmbeddedEthereumProvider` asserts it on every request — and rejects everything once the active wallet moves on.

- `useSponsoredSender` cached its smart account in a ref that was never invalidated, so after a wallet switch it kept building operations with the old address as `sender` while the signer used the new key. The EntryPoint reports that only as a generic signature error.
- The Zama runtime signed through wagmi's connector, whose provider had been built earlier in the session.

The sender now takes its address from `useEthereumEmbeddedWallet()` and rebuilds when it changes, the Zama runtime builds its wallet client from `activeWallet.getProvider()`, and every signature is recovered and checked against `sender` before submission so a drift names both addresses instead of failing opaquely at the bundler.

## The bundler's gas floor moves

Both actions then hit `maxPriorityFeePerGas must be at least 20501760 (current maxPriorityFeePerGas: 20000000)`. The floor tracks the base fee, so the fixed multiplier that cleared it during development stopped clearing it. The bundler names the figure it wants, so `send()` now reads it out of the rejection and retries with headroom — one round per field, plus room for the floor drifting between attempts.

## Batch state was reported wrong, and never polled

A settled batch rendered as **Open**. Read directly from the depositBatcher on Sepolia:

```
currentBatchId: 2270
  batch 2265  state=Finalized
  batch 2266  state=3
  batch 2270  state=Open        user position: 0xe4ced3b8241777e3…
```

The batcher returns `3` for most settled batches, but the label array had three entries and fell back to `'Open'` past them — so `0=Open 1=Dispatched 2=Finalized`, the comment in the integration reference this recipe was built from, is not the whole enum. Anything from 2 up is claimable, which is what the claim gate already used, so it now reads "Ready to claim" and prints the raw number for a state we haven't seen rather than inventing a name for it.

Nothing polled the state either: an off-chain operator settles the batch with no event to watch, so a row only moved when you opened it and tapped Refresh. The pending list now polls every 30s and the batch page every 15s until the batch is claimable.

Deposit tracking itself was correct — the recorded batch id matches the one holding the encrypted position on-chain.

`tsc -b`, `biome check` and `vite build` clean.