### PR TITLE
fix(lighter): default LIGHTER_API_KEY_INDEX to 4

### DIFF
--- a/lighter/server/.env.example
+++ b/lighter/server/.env.example
@@ -48,4 +48,5 @@ LIGHTER_CHAIN_ID=300
 # restoring a key you already have from elsewhere.
 LIGHTER_ACCOUNT_INDEX=
 LIGHTER_API_KEY_PRIVATE_KEY=
-LIGHTER_API_KEY_INDEX=2
+# Lighter reserves indices 0-3 for its own desktop/mobile interfaces; use 4-254.
+LIGHTER_API_KEY_INDEX=4

--- a/lighter/server/signer/README.md
+++ b/lighter/server/signer/README.md
@@ -37,6 +37,12 @@ recipe uses:
 - `CreateAuthToken(deadline, apiKeyIndex, accountIndex)` — signs a bearer token for authenticated
   read endpoints.
 
+Every `Sign*` binding takes a `skipNonce` flag ahead of `nonce`. This recipe always passes `0`,
+which keeps Lighter's default `new_nonce = old_nonce + 1` rule and so one `GET /api/v1/nextNonce`
+per signature. Passing `1` sets the `SkipNonce` L2 tx attribute instead: any strictly increasing
+nonce below 2^47 - 1 is accepted, so a latency-sensitive signer can keep its own counter locally
+and drop that round-trip (see https://apidocs.lighter.xyz/docs/api-keys).
+
 All signing happens entirely inside the WASM sandbox; private key material never leaves the Go
 runtime's memory as a JS value except as the hex string returned by `GenerateAPIKey`.
 

--- a/lighter/server/src/config.ts
+++ b/lighter/server/src/config.ts
@@ -84,7 +84,10 @@ export function loadConfig(): Config {
       chainId: toNumber(process.env["LIGHTER_CHAIN_ID"], 300),
       accountIndex: toNullableNumber(process.env["LIGHTER_ACCOUNT_INDEX"]),
       apiKeyPrivateKey: process.env["LIGHTER_API_KEY_PRIVATE_KEY"]?.trim() || null,
-      apiKeyIndex: toNumber(process.env["LIGHTER_API_KEY_INDEX"], 2), // 0/1 are commonly used by the web UI
+      // Lighter reserves API key indices 0-3 for its own desktop/mobile interfaces, so start at 4:
+      // registering into that range collides with the user's front-end session, and re-authorizing on
+      // Lighter's front-end resets those slots. https://apidocs.lighter.xyz/docs/api-keys
+      apiKeyIndex: toNumber(process.env["LIGHTER_API_KEY_INDEX"], 4),
     },
   };
 }


### PR DESCRIPTION
Lighter reserves API key indices **0–3** for its own desktop and mobile interfaces ([API keys docs](https://apidocs.lighter.xyz/docs/api-keys)); Robinhood Chain's docs also list `157`. The recipe server defaulted to `2`, which is inside that range: it shares a slot with the user's own Lighter front-end session, and re-authorizing on Lighter's front-end resets keys 0–3 — silently invalidating the server's key and surfacing later as a `21120 invalid signature` at startup self-test.

- `server/src/config.ts`: default `apiKeyIndex` 2 → 4, with the reason and a link to the docs.
- `server/.env.example`: `LIGHTER_API_KEY_INDEX=4` plus the reserved-range note.
- `server/signer/README.md`: document the `skipNonce` flag every `Sign*` binding takes. The recipe passes `0` (strict `old_nonce + 1`, one `nextNonce` call per signature); passing `1` accepts any strictly increasing nonce below 2^47 − 1, so a latency-sensitive signer can keep its own counter. Behavior unchanged.

Existing servers that already adopted a key at index 2 keep working — the adopted index is persisted in `.env.local` and only new setups pick up the default.

Docs counterpart: openfort-xyz/documentation#481

### Checks
`npm test` in `lighter/server`: 66 tests across 10 files pass. `npm run build` (tsc) clean. Not exercised end to end against live Lighter.

Prompted by: Joan Alavedra