### PR TITLE
Lighter: offer only markets that can fill an order

### DIFF
--- a/lighter/AGENTS.md
+++ b/lighter/AGENTS.md
@@ -49,7 +49,21 @@ Openfort or any other keychain-dependent SDK.
   `OPENFORT_ETHEREUM_PROVIDER_POLICY_ID` value, new field name. See `app/_layout.tsx`.
 - Testnet onboarding needs zero wallet signatures for funding — `POST /api/lighter/faucet`
   (server-gated to testnet only) creates AND credits the Lighter account in one call. Mainnet
-  keeps the real `approve` + `deposit` flow in `services/depositFlow.ts` untouched.
+  keeps the real `approve` + `deposit` flow in `services/depositFlow.ts` untouched. The call
+  returns before the credit lands, so `OnboardingStatusScreen` holds a spinner until the poll
+  advances the step — don't "simplify" that back into the button's own `loading` prop.
+- **App-side env changes require a native rebuild.** `Constants.expoConfig.extra` is read from
+  `EXConstants.bundle/app.config`, a snapshot generated into the `.app` at build time — the Metro
+  manifest is ignored for `extra`. Editing `lighter/.env.local` and restarting Metro silently
+  leaves the app on the old values (this cost a full debug cycle chasing a Shield 401 that was
+  really a stale publishable key). Rebuild + reinstall. `server/.env.local` needs only a restart.
+- A market being `status: "active"` does NOT mean it can be traded. Testnet lists 176 active
+  markets and ~3 have a two-sided book; the rest reject orders with "order book is empty".
+  `server/src/markets.ts` resolves this into a `hasLiquidity` flag and the app lists only those.
+  Note what does NOT work as a shortcut: `daily_quote_token_volume` is 0 for every testnet market
+  (so there is nothing to rank by), and `last_trade_price > 0` over-selects — LIT and ZORA both
+  report a last trade yet hold no resting orders. Only the order book itself is authoritative, so
+  the cheap fields are used purely to prefilter which books are worth probing.
 - Login is explicit-only, no cold-launch auto-restore: `app/index.tsx` signs out any session the
   SDK silently restored from storage before ever rendering (see `hooks/authGate.ts`'s
   `deriveAuthScreen`), so every launch lands on `LoginScreen`. Guest is ephemeral (a fresh

--- a/lighter/README.md
+++ b/lighter/README.md
@@ -120,8 +120,12 @@ faucet to real deposit automatically — no app-side config needed.
 - Testnet: one-call faucet funding. Mainnet: real USDC deposit flow (ERC-20 approve + Lighter
   contract deposit), config-switchable, no code changes
 - ChangePubKey API key registration via `personal_sign`
-- Asset selector across every active market (perp + spot — 5 on testnet today, discovered live,
-  never hardcoded) with a mini portfolio card (balance + open positions)
+- Asset selector over the markets that can actually be traded, discovered live and never
+  hardcoded. "Active" is not the same as tradeable: Lighter lists 176 active markets on testnet
+  and typically only three of them (ETH, BTC, SOL) have a two-sided order book at any given
+  moment — an order on any of the rest comes back "order book is empty". The server checks the
+  book and the app hides the dead ones. Perps and spot get separate sections when both are
+  present; testnet is perps-only today. Mini portfolio card alongside (balance + open positions)
 - Cash App-style buy/sell flow per asset with a live order book, IOC marketable-limit orders, and
   an order confirmation screen showing the actual matched size/price — the server polls Lighter's
   own trade record before responding, since `sendTx` itself reports no fill status
@@ -139,8 +143,19 @@ faucet to real deposit automatically — no app-side config needed.
   only shows up if the server's key genuinely doesn't match what's on-chain (a hand-edited
   `server/.env.local`, a second server instance, or an adoption lost to a restart before it could
   persist). Tap **Re-authorize** — the server adopts the fresh key automatically, no manual step.
+- **Changed a key in `.env.local` but the app still uses the old one** — the app's half of the
+  config is baked into the native binary at build time (`EXConstants.bundle/app.config`), so
+  editing `.env.local` and restarting Metro changes nothing: `Constants.expoConfig.extra` is read
+  from that snapshot, not from the Metro manifest. Rebuild and reinstall (`pnpm run ios`) — once a
+  first build exists the incremental one takes seconds. `server/.env.local` is the opposite: a
+  plain server restart is enough.
+- **Only two or three assets in the list** — expected on testnet. Every other listed market has an
+  empty order book and is hidden rather than offered, since an order there can't fill. The count
+  of hidden markets is shown under the list.
 - **Funds don't show up** — both the faucet (seconds) and a real deposit (minutes) take a moment
-  to land; pull to refresh on the onboarding screen.
+  to land; the onboarding screen polls every 2s and advances on its own. After tapping "Get
+  testnet funds" the card shows a spinner until the credit lands — the faucet call returns before
+  Lighter has actually credited the account.
 - **Order fails with a stale-key error** — tap **Re-authorize** from the alert; the server adopts
   the fresh key immediately, no restart needed.
 

--- a/lighter/components/AssetSelectScreen.tsx
+++ b/lighter/components/AssetSelectScreen.tsx
@@ -18,8 +18,37 @@ function formatPrice(market: Market): string {
   return value >= 100 ? value.toFixed(2) : value.toFixed(4);
 }
 
+const TYPE_LABELS: Record<Market["marketType"], string> = { perp: "Perps", spot: "Spot" };
+
 export function AssetSelectScreen({ account, onSelect, onWithdraw }: AssetSelectScreenProps) {
   const { markets, isLoading } = useLighterMarkets();
+
+  // Only markets that can actually fill an order are offered. Listing the rest is what produced
+  // "no liquidity, order book is empty" *after* picking an asset and typing an amount — on
+  // testnet that was 173 of 176 markets, so the dead ones were the overwhelming majority.
+  const tradeable = markets.filter((market) => market.hasLiquidity);
+  const hiddenCount = markets.length - tradeable.length;
+
+  // Group only when there's something to separate. Lighter testnet currently lists perps and no
+  // spot markets at all, so an unconditional split would render a permanently empty "Spot"
+  // heading; mainnet has both and gets the two sections.
+  const presentTypes = (["perp", "spot"] as const).filter((type) =>
+    tradeable.some((market) => market.marketType === type),
+  );
+  const sections = presentTypes.map((type) => ({
+    type,
+    markets: tradeable.filter((market) => market.marketType === type),
+  }));
+
+  const renderTile = (market: Market) => (
+    <TouchableOpacity key={market.marketIndex} style={styles.tile} onPress={() => onSelect(market)} activeOpacity={0.7}>
+      <View>
+        <Text style={styles.symbol}>{market.symbol}</Text>
+        <Text style={styles.type}>{market.marketType === "perp" ? "Perp" : "Spot"}</Text>
+      </View>
+      <Text style={styles.price}>${formatPrice(market)}</Text>
+    </TouchableOpacity>
+  );
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -28,23 +57,25 @@ export function AssetSelectScreen({ account, onSelect, onWithdraw }: AssetSelect
 
       {isLoading && markets.length === 0 ? (
         <ActivityIndicator color={COLORS.accent} style={styles.spinner} />
+      ) : tradeable.length === 0 ? (
+        <Text style={styles.emptyState}>
+          No market has a live order book right now. Lighter&apos;s testnet books come and go — pull back in a
+          moment.
+        </Text>
       ) : (
-        <View style={styles.list}>
-          {markets.map((market) => (
-            <TouchableOpacity
-              key={market.marketIndex}
-              style={styles.tile}
-              onPress={() => onSelect(market)}
-              activeOpacity={0.7}
-            >
-              <View>
-                <Text style={styles.symbol}>{market.symbol}</Text>
-                <Text style={styles.type}>{market.marketType === "perp" ? "Perp" : "Spot"}</Text>
-              </View>
-              <Text style={styles.price}>${formatPrice(market)}</Text>
-            </TouchableOpacity>
-          ))}
-        </View>
+        sections.map((section) => (
+          <View key={section.type} style={styles.section}>
+            {sections.length > 1 && <Text style={styles.sectionHeading}>{TYPE_LABELS[section.type]}</Text>}
+            <View style={styles.list}>{section.markets.map(renderTile)}</View>
+          </View>
+        ))
+      )}
+
+      {hiddenCount > 0 && (
+        <Text style={styles.hiddenNote}>
+          {hiddenCount} listed {hiddenCount === 1 ? "market has" : "markets have"} no order book right now and
+          {hiddenCount === 1 ? " is" : " are"} hidden — an order there can&apos;t fill.
+        </Text>
       )}
 
       <TouchableOpacity onPress={onWithdraw}>
@@ -72,6 +103,26 @@ const styles = StyleSheet.create({
   },
   spinner: {
     marginTop: 24,
+  },
+  section: {
+    gap: 10,
+  },
+  sectionHeading: {
+    color: COLORS.textSecondary,
+    fontSize: 13,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+  },
+  emptyState: {
+    color: COLORS.textSecondary,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  hiddenNote: {
+    color: COLORS.textTertiary,
+    fontSize: 12,
+    lineHeight: 17,
   },
   list: {
     gap: 10,

--- a/lighter/components/onboarding/OnboardingStatusScreen.tsx
+++ b/lighter/components/onboarding/OnboardingStatusScreen.tsx
@@ -54,6 +54,8 @@ export function OnboardingStatusScreen({ walletAddress, provider, onboarding, ke
   const { step, account, serverConfig, accountMismatch, isLoading, error, refresh } = onboarding;
   const isTestnet = serverConfig?.network === "testnet";
   const [isFauceting, setIsFauceting] = useState(false);
+  // Faucet call accepted, funds not yet visible — see handleFaucet.
+  const [hasRequestedFaucet, setHasRequestedFaucet] = useState(false);
 
   // Adjusting state during render (React's recommended pattern for "reset when an input
   // changes") rather than in an effect — any step transition proves the poll caught up to
@@ -62,6 +64,7 @@ export function OnboardingStatusScreen({ walletAddress, provider, onboarding, ke
   if (step !== prevStep) {
     setPrevStep(step);
     setHasSignedThisSession(false);
+    setHasRequestedFaucet(false);
   }
 
   // ChangePubKey submit makes the server adopt the fresh key immediately (see
@@ -78,12 +81,17 @@ export function OnboardingStatusScreen({ walletAddress, provider, onboarding, ke
     setIsFauceting(true);
     try {
       await requestFaucet(walletAddress);
-      // No success alert — the 2s poll advances the step automatically the moment it lands.
+      // The request returning is not the funds arriving — Lighter credits the account
+      // asynchronously, seconds later. Without this the button would snap back to its idle label
+      // with nothing on screen having changed, which reads as "the tap did nothing". Cleared by
+      // the step-change reset below, once the 2s poll sees the balance.
+      setHasRequestedFaucet(true);
     } catch {
       // The server already retried a few times — Lighter's testnet faucet is intermittently
       // flaky. Refresh immediately in case an earlier retry actually
       // succeeded upstream despite this final attempt reporting failure.
       await refresh();
+      setHasRequestedFaucet(false);
       Alert.alert("Faucet unavailable", "Try again — Lighter's testnet faucet is a bit flaky.");
     } finally {
       setIsFauceting(false);
@@ -177,8 +185,16 @@ export function OnboardingStatusScreen({ walletAddress, provider, onboarding, ke
       {step === "deposit" && serverConfig && isTestnet && (
         <View style={styles.card}>
           <Text style={styles.cardTitle}>Get testnet funds</Text>
-          <Text style={styles.cardBody}>One tap. No signature, no real money.</Text>
-          <PillButton title="Get testnet funds" onPress={handleFaucet} loading={isFauceting} />
+          <Text style={styles.cardBody}>
+            {hasRequestedFaucet
+              ? "Requested. Lighter credits the account a few seconds later — this advances on its own the moment the funds land."
+              : "One tap. No signature, no real money."}
+          </Text>
+          {hasRequestedFaucet ? (
+            <ActivityIndicator color={COLORS.accent} />
+          ) : (
+            <PillButton title="Get testnet funds" onPress={handleFaucet} loading={isFauceting} />
+          )}
         </View>
       )}
 

--- a/lighter/scripts/e2e.md
+++ b/lighter/scripts/e2e.md
@@ -78,6 +78,11 @@ first.
 Same as mainnet steps B4-B6 below, just with testnet play-money — go do them now, then come back
 here. Everything after onboarding is network-agnostic (same signer, same server routes).
 
+**Expect a short asset list.** Lighter's testnet lists ~176 active markets but only the handful
+with a live two-sided book (usually ETH, BTC, SOL) are offered; the rest are hidden because an
+order there is rejected with "order book is empty". A count of what was hidden appears under the
+list. If the list is ever empty, no market has a book at that moment — wait and it repopulates.
+
 ---
 
 ## Path B — Mainnet (real funds, do this once testnet works)

--- a/lighter/server/src/lighterApi.ts
+++ b/lighter/server/src/lighterApi.ts
@@ -133,6 +133,7 @@ export interface LighterOrderBookDetail {
   supported_quote_decimals: number;
   mark_price?: string;
   last_trade_price?: number;
+  open_interest?: number;
 }
 
 /**

--- a/lighter/server/src/markets.test.ts
+++ b/lighter/server/src/markets.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LighterApiError } from "./lighterApi.js";
 import { requireMarket, type Market } from "./markets.js";
+import type { Config } from "./config.js";
 
 const ETH: Market = {
   marketIndex: 0,
@@ -11,6 +12,7 @@ const ETH: Market = {
   minBaseAmount: "0.0050",
   minQuoteAmount: "10.000000",
   price: "1803.19",
+  hasLiquidity: true,
 };
 
 const LIT_USDC: Market = {
@@ -22,6 +24,7 @@ const LIT_USDC: Market = {
   minBaseAmount: "50",
   minQuoteAmount: "10.000000",
   price: "0.0001",
+  hasLiquidity: false,
 };
 
 describe("requireMarket", () => {
@@ -37,5 +40,113 @@ describe("requireMarket", () => {
 
   it("throws for an empty market list (e.g. upstream returned nothing active)", () => {
     expect(() => requireMarket([], 0)).toThrow(LighterApiError);
+  });
+});
+
+describe("getActiveMarkets liquidity", () => {
+  const config = {
+    port: 3008,
+    allowedOrigins: [],
+    authToken: "",
+    openfort: { secretKey: "", shield: { publishableKey: "", secretKey: "", encryptionShare: "" } },
+    lighter: {
+      apiBaseUrl: "https://testnet.zklighter.elliot.ai",
+      chainId: 300,
+      accountIndex: null,
+      apiKeyPrivateKey: null,
+      apiKeyIndex: 2,
+    },
+  } as Config;
+
+  const detail = (market_id: number, symbol: string, extra: Record<string, unknown>) => ({
+    market_id,
+    symbol,
+    market_type: "perp",
+    status: "active",
+    min_base_amount: "0.0050",
+    min_quote_amount: "10.000000",
+    supported_size_decimals: 4,
+    supported_price_decimals: 2,
+    supported_quote_decimals: 6,
+    mark_price: "100.00",
+    ...extra,
+  });
+
+  // 0 = trades + a two-sided book (genuinely tradeable)
+  // 1 = has traded before but nothing resting now (the LIT/ZORA case a cheap proxy gets wrong)
+  // 2 = never traded, no open interest (must be excluded without spending a probe on it)
+  const DETAILS = [
+    detail(0, "ETH", { last_trade_price: 2488, open_interest: 5.9 }),
+    detail(1, "LIT", { last_trade_price: 4.68, open_interest: 0 }),
+    detail(2, "DUSK", { last_trade_price: 0, open_interest: 0 }),
+  ];
+
+  let probed: number[] = [];
+
+  beforeEach(() => {
+    probed = [];
+    vi.resetModules(); // the liquidity cache is module state — each test needs a fresh one
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        const parsed = new URL(url);
+        if (parsed.pathname === "/api/v1/orderBookDetails") {
+          return { ok: true, json: async () => ({ code: 200, order_book_details: DETAILS, spot_order_book_details: [] }) };
+        }
+        const marketId = Number(parsed.searchParams.get("market_id"));
+        probed.push(marketId);
+        const book =
+          marketId === 0
+            ? { code: 200, bids: [{ price: "2487" }], asks: [{ price: "2489" }] }
+            : { code: 200, bids: [], asks: [] };
+        return { ok: true, json: async () => book };
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("marks only markets with a two-sided book as tradeable", async () => {
+    const { getActiveMarkets } = await import("./markets.js");
+    const markets = await getActiveMarkets(config);
+    expect(markets.map((m) => [m.symbol, m.hasLiquidity])).toEqual([
+      ["ETH", true],
+      ["LIT", false],
+      ["DUSK", false],
+    ]);
+  });
+
+  it("probes only the prefiltered candidates, never every active market", async () => {
+    const { getActiveMarkets } = await import("./markets.js");
+    await getActiveMarkets(config);
+    // DUSK never traded and holds no open interest, so it must cost zero requests.
+    expect(probed.sort()).toEqual([0, 1]);
+  });
+
+  it("keeps a market visible when its probe errors rather than hiding something tradeable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        const parsed = new URL(url);
+        if (parsed.pathname === "/api/v1/orderBookDetails") {
+          return { ok: true, json: async () => ({ code: 200, order_book_details: DETAILS, spot_order_book_details: [] }) };
+        }
+        throw new Error("upstream blip");
+      }),
+    );
+    const { getActiveMarkets } = await import("./markets.js");
+    const markets = await getActiveMarkets(config);
+    expect(markets.find((m) => m.symbol === "ETH")?.hasLiquidity).toBe(true);
+    expect(markets.find((m) => m.symbol === "DUSK")?.hasLiquidity).toBe(false);
+  });
+
+  it("serves the cached liquidity set on a second call instead of re-probing", async () => {
+    const { getActiveMarkets } = await import("./markets.js");
+    await getActiveMarkets(config);
+    const afterFirst = probed.length;
+    await getActiveMarkets(config);
+    expect(probed.length).toBe(afterFirst);
   });
 });

--- a/lighter/server/src/markets.ts
+++ b/lighter/server/src/markets.ts
@@ -1,5 +1,5 @@
 import type { Config } from "./config.js";
-import { LighterApiError, getOrderBookDetails } from "./lighterApi.js";
+import { LighterApiError, getOrderBookDetails, getOrderBookOrders, type LighterOrderBookDetail } from "./lighterApi.js";
 
 export interface Market {
   marketIndex: number;
@@ -11,28 +11,76 @@ export interface Market {
   minQuoteAmount: string;
   /** Mark price for perps, last trade price for spot — whichever Lighter reports as "current". */
   price: string;
+  /**
+   * True only if this market has resting orders on BOTH sides right now, i.e. a marketable order
+   * can actually fill. "Active" status alone does not imply this: testnet lists 176 active
+   * markets and exactly 3 of them (ETH/BTC/SOL) have a book — every other one takes an order and
+   * rejects it with "order book is empty".
+   */
+  hasLiquidity: boolean;
+}
+
+const LIQUIDITY_TTL_MS = 15_000;
+let liquidityCache: { at: number; tradeable: Set<number> } | null = null;
+
+/**
+ * Which markets can actually fill an order right now.
+ *
+ * Only the order book proves this, and probing all 176 active markets on every 3s poll is out of
+ * the question — so this narrows first on the one bulk call we already made: a market that has
+ * never traded AND holds no open interest has no book worth checking. That prefilter cuts 176
+ * candidates to ~5, and only those get a book probe. Cheap proxies alone are not enough: LIT and
+ * ZORA both report last_trade_price > 0 yet have no resting orders, so trusting the prefilter
+ * would put two dead markets back in the list.
+ *
+ * ponytail: misses a market seeded with a fresh two-sided book that has never traded and shows no
+ * open interest. Lighter's testnet maker quotes and trades the same markets, so that combination
+ * doesn't occur today; if it ever does, drop the prefilter and probe every active market behind a
+ * longer TTL.
+ */
+async function getTradeableMarketIndexes(config: Config, details: LighterOrderBookDetail[]): Promise<Set<number>> {
+  if (liquidityCache && Date.now() - liquidityCache.at < LIQUIDITY_TTL_MS) {
+    return liquidityCache.tradeable;
+  }
+  const candidates = details.filter(
+    (detail) => Number(detail.last_trade_price ?? 0) > 0 || Number(detail.open_interest ?? 0) > 0,
+  );
+  const probes = await Promise.all(
+    candidates.map(async (detail) => {
+      try {
+        const book = await getOrderBookOrders(config, detail.market_id, 1);
+        return book.bids.length > 0 && book.asks.length > 0 ? detail.market_id : null;
+      } catch {
+        // A probe failure is not proof of an empty book — leave the market in rather than hiding
+        // something tradeable because one request blipped.
+        return detail.market_id;
+      }
+    }),
+  );
+  const tradeable = new Set(probes.filter((id): id is number => id !== null));
+  liquidityCache = { at: Date.now(), tradeable };
+  return tradeable;
 }
 
 /**
- * Returns every currently active market (perp + spot) with live pricing, sourced fresh from
- * Lighter on each call — no local caching, so this always reflects the true tradeable set
- * (testnet has exactly 5 today: ETH/BTC/SOL perps + ETH/USDC, LIT/USDC spot, but nothing here
- * hardcodes that list).
+ * Returns every currently active market (perp + spot) with live pricing and whether it can
+ * actually be traded, sourced fresh from Lighter on each call (the liquidity half is cached for
+ * LIQUIDITY_TTL_MS). Nothing here hardcodes a market list.
  */
 export async function getActiveMarkets(config: Config): Promise<Market[]> {
-  const details = await getOrderBookDetails(config);
-  return details
-    .filter((detail) => detail.status === "active")
-    .map((detail) => ({
-      marketIndex: detail.market_id,
-      symbol: detail.symbol,
-      marketType: detail.market_type,
-      sizeDecimals: detail.supported_size_decimals,
-      priceDecimals: detail.supported_price_decimals,
-      minBaseAmount: detail.min_base_amount,
-      minQuoteAmount: detail.min_quote_amount,
-      price: detail.mark_price ?? String(detail.last_trade_price ?? "0"),
-    }));
+  const details = (await getOrderBookDetails(config)).filter((detail) => detail.status === "active");
+  const tradeable = await getTradeableMarketIndexes(config, details);
+  return details.map((detail) => ({
+    marketIndex: detail.market_id,
+    symbol: detail.symbol,
+    marketType: detail.market_type,
+    sizeDecimals: detail.supported_size_decimals,
+    priceDecimals: detail.supported_price_decimals,
+    minBaseAmount: detail.min_base_amount,
+    minQuoteAmount: detail.min_quote_amount,
+    price: detail.mark_price ?? String(detail.last_trade_price ?? "0"),
+    hasLiquidity: tradeable.has(detail.market_id),
+  }));
 }
 
 /**

--- a/lighter/services/lighterServerClient.ts
+++ b/lighter/services/lighterServerClient.ts
@@ -108,9 +108,15 @@ export interface Market {
   minBaseAmount: string;
   minQuoteAmount: string;
   price: string;
+  /** Has resting orders on both sides right now — see the server's markets.ts for why "active" isn't enough. */
+  hasLiquidity: boolean;
 }
 
-/** All currently active markets (perp + spot), with live prices — discovered fresh each call. */
+/**
+ * All currently active markets (perp + spot) with live prices, discovered fresh each call. Each
+ * carries `hasLiquidity` — active is not the same as tradeable, so callers offering a market to
+ * the user should filter on it.
+ */
 export function fetchMarkets(): Promise<{ markets: Market[] }> {
   return request("/api/lighter/markets");
 }


### PR DESCRIPTION
Two onboarding fixes found while running the recipe end to end from zero on testnet.

## Only list tradeable markets

`status: "active"` does not mean a market can fill an order. Lighter's testnet lists 176 active markets, and typically three of them (ETH, BTC, SOL) hold resting orders on both sides. Picking any of the other 173 showed a ticker with no value and then failed with "no liquidity, order book is empty" — after the user had already chosen an asset and typed an amount.

`Market.hasLiquidity` is now computed server-side and the asset selector lists only those, with a count of what was hidden underneath.

The check is two-stage because neither cheap field in `orderBookDetails` is sufficient:

- `daily_quote_token_volume` reads `0` for **every** testnet market, so there is nothing to rank by.
- `last_trade_price > 0` over-reports — LIT and ZORA both traded at some point and hold no resting orders now.

So it prefilters on `last_trade_price > 0 || open_interest > 0` (176 candidates down to ~5) and confirms each survivor against the actual book. 6 requests instead of 177, cached 15s against the client's 3s poll: 2.4s cold, 0.5s warm. A probe that errors leaves the market visible rather than hiding something tradeable.

Perps and spot render as separate sections only when both are present — testnet is perps-only today and would otherwise show a permanently empty "Spot" heading.

## Hold the faucet card until funds land

The faucet request returns as soon as Lighter accepts it, seconds before the account is credited, so the button snapped back to its idle label with nothing on screen having changed — it read as "the tap did nothing". The `loading` prop was never the problem. The card now holds a spinner and an explanatory line until the 2s poll advances the step.

## Docs

- `README.md` — corrected the stale "5 on testnet" feature claim; troubleshooting entries for the short asset list and for app-side env changes needing a native rebuild (`Constants.expoConfig.extra` comes from a build-time `EXConstants.bundle` snapshot, so editing `.env.local` and restarting Metro silently keeps the old values).
- `AGENTS.md` — the same three notes for whoever picks this up next, including which market fields do *not* work as a liquidity shortcut.
- `scripts/e2e.md` — tells the tester to expect a short asset list rather than assume it's broken.

Matching docs change in openfort-xyz/documentation.

## Verification

- Server: `tsc --noEmit` clean, 70 tests pass (4 new, covering the flags, that only prefiltered candidates are probed, the probe-error fallback, and the cache).
- App: `tsc --noEmit` and `eslint` clean.
- Ran live against testnet: `/api/lighter/markets` returns 178 markets with 3 flagged tradeable (ETH/BTC/SOL), and the full guest → faucet → authorize → trade flow works from zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)