### PR TITLE
[virtual-accounts] Add Noah virtual bank accounts recipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 ## Project overview
-- Collection of Openfort integration samples (`7702`, `aave`, `agent-permissions`, `hyperliquid`, `lifi`, `morpho`, `mpp`, `near-intents`, `telegram-bot`, `usdc`, `vaults-fyi`, `x402`).
+- Collection of Openfort integration samples (`7702`, `aave`, `agent-permissions`, `hyperliquid`, `lifi`, `morpho`, `mpp`, `near-intents`, `telegram-bot`, `usdc`, `vaults-fyi`, `virtual-accounts`, `x402`).
 - Each subdirectory has its own `AGENTS.md` with detailed setup instructions; start at the sample you are modifying.
 
 ## Setup commands

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains comprehensive samples demonstrating how to integrate Op
 | **[Earn private yield with Zama](./zama-confidential-yield/)** | Shield USDC into confidential cUSDC and earn private yield in Zama's Steakhouse Confidential Morpho vault. Balances stay encrypted; gasless embedded EOA (passkey, EIP-7702 delegated) on Ethereum Sepolia. | `pnpx gitpick openfort-xyz/recipes-hub/tree/main/zama-confidential-yield openfort-zama-yield && cd openfort-zama-yield` |
 | **[Telegram wallet bot](./telegram-bot/)**                  | Telegram bot where every user gets their own server-side wallet, keyed by Telegram user ID. Chat commands create wallets, check balances, and send USDC with sponsored gas on Base Sepolia. | `pnpx gitpick openfort-xyz/recipes-hub/tree/main/telegram-bot openfort-telegram-bot && cd openfort-telegram-bot` |
 | **[Trade on Lighter](./lighter/)**                            | Mainnet perps trading on the Lighter zk L2 DEX. Embedded wallet authorizes account registration and deposits; a backend holds the Lighter API key and signs orders via a vendored WASM build of lighter-go. | `pnpx gitpick openfort-xyz/recipes-hub/tree/main/lighter openfort-lighter && cd openfort-lighter`             |
+| **[Virtual bank accounts](./virtual-accounts/)**              | Issue each user a US account number (ACH/wire) or a European IBAN (SEPA) with Noah. Deposits auto-convert to USDC and settle to their embedded wallet on Polygon. | `pnpx gitpick openfort-xyz/recipes-hub/tree/main/virtual-accounts openfort-virtual-accounts && cd openfort-virtual-accounts` |
 
 ## Getting Started
 
@@ -38,4 +39,5 @@ Each sample is completely self-contained with its own setup instructions, enviro
 | **Zama Yield**          | React + Vite | -          | Ethereum Sepolia  | `@zama-fhe/sdk`, `@openfort/react`, `wagmi`, `viem`  |
 | **Telegram bot**        | -            | Node.js    | Base Sepolia      | `grammy`, `@openfort/openfort-node`, `viem`          |
 | **Lighter**             | React Native | Node.js    | Ethereum mainnet  | `@openfort/react-native`, vendored `lighter-go` WASM |
+| **Virtual accounts**    | React + Vite | Express.js | Polygon Amoy      | Noah API, `@openfort/react`, `wagmi`, `viem`         |
 

--- a/virtual-accounts/AGENTS.md
+++ b/virtual-accounts/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md — virtual-accounts
+
+## Overview
+
+Issue Noah virtual bank accounts (USD ACH / EUR SEPA IBAN) against an Openfort embedded wallet. Fiat
+deposited to the account is converted to USDC and sent on-chain to that wallet.
+
+- `frontend/` — Vite + React. Openfort provider (Polygon Amoy + EOA + passkey), KYC gate, currency
+  toggle, account details, sandbox deposit simulation, USDC balance.
+- `backend/` — Express. Validates the Openfort session token, then calls Noah with a server-only API key.
+
+## Setup commands
+
+```bash
+cd backend && pnpm i && pnpm dev      # http://localhost:3021
+cd frontend && pnpm i && pnpm dev     # http://localhost:5182
+```
+
+Copy `backend/.env.local.example` → `backend/.env.local` and `frontend/.env.example` → `frontend/.env`.
+Hosted KYC needs an HTTPS `PUBLIC_APP_URL`, so run a tunnel to the frontend in local development.
+
+## Testing / checks
+
+- Backend: `pnpm build` (tsc). Liveness: `curl localhost:3021/api/health`. Every `/api/banking/*` route
+  except the webhook returns `401` without a valid Openfort bearer token; the webhook returns `401`
+  without a valid `Webhook-Signature`.
+- Frontend: `pnpm build` (tsc + vite). Lint/format: `pnpm check` (Biome).
+
+## Key constraints
+
+- **The Openfort user id is the Noah `CustomerID`.** No user table; changing that mapping orphans every
+  issued account.
+- **`FiatCurrency` is the only rail switch.** Read `PaymentMethodType` from the response
+  (`BankAch` / `BankSepa`) to decide whether `AccountNumber` is an account number or an IBAN and whether
+  `BankCode` is a routing number or a BIC — never assume from the request.
+- **Request signing is production-only here.** `noah.ts` signs whenever `NOAH_SIGNING_PRIVATE_KEY` is
+  set. In sandbox, sending a signature from a public key Noah has not registered fails with
+  `401 "public key not found"` — leave the variable empty unless the key was created with a signing key.
+- **The webhook needs the raw body.** `express.raw` is mounted on `/api/banking/webhooks` before
+  `express.json()`; parsing first breaks ECDSA SHA-384 verification.
+- **Sandbox tokens carry a `_TEST` suffix** (`USDC_TEST` on `PolygonTestAmoy`). `NOAH_ENVIRONMENT`
+  drives base URL, token, and network together — don't set them independently.
+- **`@openfort/react` is pinned to `1.3.0`** (needs `AccountTypeEnum.EOA`, `useEthereumEmbeddedWallet`,
+  `uiConfig.walletRecovery`). Keep `wagmi` on `3.x` and `viem` on `2.x` to match. wagmi 3's `useBalance`
+  is native-only, so the USDC balance uses `useReadContract` + `balanceOf`.
+- **Passkey-only recovery** — no `getEncryptionSession` / automatic-recovery endpoint.

--- a/virtual-accounts/AGENTS.md
+++ b/virtual-accounts/AGENTS.md
@@ -30,9 +30,13 @@ Hosted KYC needs an HTTPS `PUBLIC_APP_URL`, so run a tunnel to the frontend in l
 
 - **The Openfort user id is the Noah `CustomerID`.** No user table; changing that mapping orphans every
   issued account.
-- **`FiatCurrency` is the only rail switch.** Read `PaymentMethodType` from the response
-  (`BankAch` / `BankSepa`) to decide whether `AccountNumber` is an account number or an IBAN and whether
-  `BankCode` is a routing number or a BIC — never assume from the request.
+- **Never infer the rail from the currency you asked for.** A USD account comes back as `BankSwift`
+  with `BankAch` and `BankFedwire` in `RelatedPaymentMethods` (same account number, different bank
+  code and fee); EUR comes back as a single `BankSepa`. `BankCode` is a routing number on ACH and
+  Fedwire, a BIC on SWIFT and SEPA. `pnpm test` pins this to two real sandbox responses.
+- **`NOAH_FIAT_OPTIONS` decides which entities the hosted KYC runs.** Asking for USD adds the US
+  banking partner's agreement pages; a customer whose country that entity cannot serve fails inside
+  the hosted flow (500 or "Accounts unavailable"), and no customer record is created at all.
 - **Request signing is production-only here.** `noah.ts` signs whenever `NOAH_SIGNING_PRIVATE_KEY` is
   set. In sandbox, sending a signature from a public key Noah has not registered fails with
   `401 "public key not found"` — leave the variable empty unless the key was created with a signing key.

--- a/virtual-accounts/README.md
+++ b/virtual-accounts/README.md
@@ -1,0 +1,157 @@
+# Openfort Virtual Bank Accounts
+
+Give every user their own bank account details — a **US routing and account number** or a **European
+IBAN** — and have the fiat that lands there converted to USDC and delivered to their Openfort embedded
+wallet. [Noah](https://noah.com) issues the account and runs the on-ramp; Openfort holds the keys.
+
+- **Openfort embedded EOA** — self-custodial wallet with passkey recovery on Polygon (Amoy in sandbox).
+  It is the destination address bound to the bank account.
+- **Noah virtual accounts** — hosted KYC, then one call issues an account on either rail: `USD` → ACH
+  and domestic wire, `EUR` → SEPA. Every deposit is auto-converted and sent on-chain.
+- **One switch between rails** — `FiatCurrency` is the only field that changes. The response's
+  `PaymentMethodType` (`BankAch` / `BankSepa`) tells you whether `AccountNumber` is an account number or
+  an IBAN, and whether `BankCode` is a routing number or a BIC.
+
+## How the flow works
+
+```
+ User                     Backend                         Noah                      Chain
+ ───────────────────────────────────────────────────────────────────────────────────────────
+
+  sign in ───────────────▶ Openfort embedded wallet
+                           (usr_… + 0xabc…)
+
+  verify identity ───────▶ POST /v1/onboarding/{customerId} ─────▶ hosted KYC page
+         ◀──────────────── HostedURL                                     │
+                                  ◀──────── Customer webhook ────────────┘  Approved
+
+  get bank details ──────▶ POST /v1/workflows/bank-deposit-to-onchain-address
+         ◀──────────────── USD → BankAch  · routing number + account number
+         ◀──────────────── EUR → BankSepa · BIC + IBAN
+
+  bank transfer ─────────────────────────────▶ fiat received
+                                               convert to USDC ───────────▶ wallet
+                                  ◀──── FiatDeposit + Transaction webhooks
+```
+
+The Openfort user id (`usr_…`) is used verbatim as the Noah `CustomerID`, so there is no user table to
+keep in sync. The Noah API key is server-only — the browser never sees it.
+
+## 1. Setup
+
+```bash
+pnpx gitpick openfort-xyz/recipes-hub/tree/main/virtual-accounts openfort-virtual-accounts && cd openfort-virtual-accounts
+```
+
+## 2. Get credentials
+
+### Openfort Dashboard ([dashboard.openfort.io](https://dashboard.openfort.io))
+
+1. **API keys** — copy the **Publishable Key** (`pk_test_...`) and **Secret Key** (`sk_test_...`).
+2. **Embedded wallet keys** — copy the Shield **Publishable Key**.
+3. Make sure **Polygon Amoy** and the **EOA** account type are enabled on the project.
+
+### Noah ([business.sandbox.noah.com](https://business.sandbox.noah.com))
+
+Sandbox registration is self-serve and free.
+
+1. Register with your business email and log in.
+2. **Configuration → API → API Keys → Create New**. Label it and copy the key — it is shown once.
+   Create it **without** a request-signing public key so unsigned sandbox calls work.
+3. Copy Noah's **webhook public key** for sandbox from their
+   [webhook docs](https://docs.noah.com/api-concepts/webhooks/configuration/) — without it the webhook
+   route rejects every delivery.
+
+Production keys are not self-serve: see [Going to production](#going-to-production).
+
+### A tunnel
+
+Noah's hosted KYC redirects back to `PUBLIC_APP_URL` and rejects `http://localhost`, so expose the
+frontend over HTTPS while developing:
+
+```bash
+ngrok http 5182     # or: cloudflared tunnel --url http://localhost:5182
+```
+
+## 3. Configure
+
+```bash
+cp backend/.env.local.example backend/.env.local     # Openfort + Noah keys, PUBLIC_APP_URL
+cp frontend/.env.example frontend/.env               # Openfort publishable + Shield key
+```
+
+## 4. Run
+
+```bash
+cd backend  && pnpm install && pnpm dev     # http://localhost:3021
+cd frontend && pnpm install && pnpm dev     # http://localhost:5182
+```
+
+Then, in the app:
+
+1. **Sign in** with an email OTP and create the wallet with a passkey.
+2. **Verify identity** — this opens Noah's hosted KYC. In sandbox you can complete it with test data;
+   the page polls until Noah reports `Approved`.
+3. Pick **USD · ACH** or **EUR · SEPA** and press **Get bank details**. The fields are labeled for the
+   rail you chose. Issuing both is fine — they point at the same wallet.
+4. **Simulate a deposit** (sandbox only). Noah runs the real conversion path and sends `USDC_TEST` to
+   the wallet, so the balance moves without a real bank transfer.
+
+## What is where
+
+| Path | What it does |
+| --- | --- |
+| `backend/src/noah.ts` | The whole Noah integration: signed HTTP client, the endpoints, webhook verification, and the rail-neutral mapping |
+| `backend/src/routes.ts` | Openfort-authenticated route handlers (customer, onboarding, virtual account, sandbox deposit, webhook) |
+| `backend/src/openfort.ts` | Validates the user's access token; the user id becomes the Noah customer id |
+| `frontend/src/screens/Dashboard.tsx` | KYC gate, currency toggle, account details, deposit simulation, USDC balance |
+| `frontend/src/lib/api.ts` | Typed client for the backend, and the per-rail field labels |
+
+## USD and EUR side by side
+
+| | USD virtual account | EUR virtual account |
+| --- | --- | --- |
+| Rails | ACH and domestic wire | SEPA credit transfer |
+| `FiatCurrency` | `USD` | `EUR` |
+| `PaymentMethodType` | `BankAch` | `BankSepa` |
+| `AccountNumber` | Account number | IBAN |
+| `BankCode` | Routing number | BIC |
+| Coverage | United States | 27 European countries |
+| Extra checks | Ownership verification may send microdeposits under $1 — each fires two `FiatDeposit` and two `Transaction` events | Deposits above €15,000 per transaction or €30,000 per month trigger enhanced due diligence |
+
+USD virtual accounts require Noah's **Standard Model** KYC — the hosted flow this recipe uses.
+
+## Going to production
+
+1. **Contact Noah** ([business@noah.com](mailto:business@noah.com)) and complete commercial onboarding
+   and KYB. Production credentials are issued by your Noah contact, not the dashboard.
+2. **Enable request signing** — mandatory in production, and Noah wants to see it working first:
+
+   ```bash
+   openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-384 -out noah_private.pem
+   openssl pkey -in noah_private.pem -pubout -out noah_public.pem
+   ```
+
+   Register `noah_public.pem` against an API key in the dashboard and put the private key in
+   `NOAH_SIGNING_PRIVATE_KEY`. Set it in sandbox first: this recipe signs whenever the variable is
+   present, so you can prove the signature before live money is involved.
+3. **Flip the environment** — `NOAH_ENVIRONMENT=production` switches the base URL to `api.noah.com`,
+   the token to `USDC`, and the network to `Polygon`. Set `VITE_NOAH_ENVIRONMENT=production` too, use
+   `pk_live_` / `sk_live_` Openfort keys, and set the **production** webhook public key.
+4. **Register the webhook** at `https://yourdomain.com/api/banking/webhooks` on the production
+   dashboard, then run one real deposit end to end before opening the flow to users.
+
+## Notes
+
+- **Re-read account details when you display them.** The assignment is stable, but bank partners and
+  account-holder names change; this recipe keeps the account in component state for the session only.
+- **The webhook signature covers the raw body.** `server.ts` mounts `express.raw` on the webhook route
+  before `express.json()` — parsing first breaks verification.
+- **Deposits are asynchronous.** The balance updates when Noah's on-chain transfer lands, which is why
+  the dashboard polls and why production apps should act on the `FiatDeposit` / `Transaction` webhooks.
+
+## Links
+
+- [Noah virtual accounts](https://docs.noah.com/products/bank-onramp/)
+- [Noah API keys and request signing](https://docs.noah.com/api-concepts/authentication/api/)
+- [Openfort embedded wallets](https://www.openfort.io/docs/products/embedded-wallet)

--- a/virtual-accounts/README.md
+++ b/virtual-accounts/README.md
@@ -92,6 +92,11 @@ Then, in the app:
 1. **Sign in** with an email OTP and create the wallet with a passkey.
 2. **Verify identity** — this opens Noah's hosted KYC. In sandbox you can complete it with test data;
    the page polls until Noah reports `Approved`.
+
+   > Ask only for the currencies you can serve. `NOAH_FIAT_OPTIONS` (default `USD,EUR`) decides which
+   > Noah entities the session runs: USD adds the US banking partner's agreement pages, and a customer
+   > whose country that entity cannot serve fails there — a 500 or "Accounts unavailable", with no
+   > customer record created. Onboarding EU customers, set `NOAH_FIAT_OPTIONS=EUR`.
 3. Pick **USD · ACH** or **EUR · SEPA** and press **Get bank details**. The fields are labeled for the
    rail you chose. Issuing both is fine — they point at the same wallet.
 4. **Simulate a deposit** (sandbox only). Noah runs the real conversion path and sends `USDC_TEST` to
@@ -111,11 +116,12 @@ Then, in the app:
 
 | | USD virtual account | EUR virtual account |
 | --- | --- | --- |
-| Rails | ACH and domestic wire | SEPA credit transfer |
+| Ways to pay it | SWIFT (primary), plus ACH and Fedwire in `RelatedPaymentMethods` | SEPA credit transfer |
 | `FiatCurrency` | `USD` | `EUR` |
-| `PaymentMethodType` | `BankAch` | `BankSepa` |
-| `AccountNumber` | Account number | IBAN |
-| `BankCode` | Routing number | BIC |
+| `PaymentMethodType` | `BankSwift`, `BankAch`, `BankFedwire` | `BankSepa` |
+| `AccountNumber` | Account number (same on all three) | IBAN |
+| `BankCode` | BIC on SWIFT, routing number on ACH and Fedwire | BIC |
+| Fee (sandbox) | $25 SWIFT · $20 Fedwire · $2.19 ACH, each + 0.15% | 1%, €1 minimum |
 | Coverage | United States | 27 European countries |
 | Extra checks | Ownership verification may send microdeposits under $1 — each fires two `FiatDeposit` and two `Transaction` events | Deposits above €15,000 per transaction or €30,000 per month trigger enhanced due diligence |
 

--- a/virtual-accounts/backend/.env.local.example
+++ b/virtual-accounts/backend/.env.local.example
@@ -21,6 +21,13 @@ NOAH_ENVIRONMENT=sandbox
 # Server-only API key. Never expose it to the browser.
 NOAH_API_KEY=
 
+# Currencies hosted KYC onboards the customer for (default USD,EUR). Each one
+# adds its Noah entity's agreements to the flow — USD brings the US banking
+# partner's forms — so onboarding a customer to an entity that cannot serve
+# their country dies inside the hosted flow, before any customer is created.
+# Onboarding EU customers only? Set EUR.
+NOAH_FIAT_OPTIONS=USD,EUR
+
 # ES384 private key (PEM, \n-escaped). Optional in sandbox when the API key was
 # created without a signing public key. MANDATORY in production:
 #   openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-384 -out noah_private.pem

--- a/virtual-accounts/backend/.env.local.example
+++ b/virtual-accounts/backend/.env.local.example
@@ -1,0 +1,33 @@
+# Server
+PORT=3021
+# Empty = allow any origin (simplest locally). In prod, list explicit origins,
+# e.g. CORS_ORIGINS=http://localhost:5182
+CORS_ORIGINS=
+
+# Public HTTPS URL of the frontend — Noah's hosted KYC redirects back to it.
+# Noah rejects http://localhost, so run a tunnel locally (ngrok, cloudflared).
+PUBLIC_APP_URL=https://your-tunnel.ngrok.app
+
+# --- Openfort (Dashboard → API Keys) — REQUIRED ---
+# Secret + publishable key from the SAME project. Together they validate the
+# user's session token; the backend never signs transactions.
+OPENFORT_SECRET_KEY=
+OPENFORT_PUBLISHABLE_KEY=
+
+# --- Noah (business.sandbox.noah.com → Configuration → API → API Keys) ---
+# sandbox | production. Sandbox picks api.sandbox.noah.com + USDC_TEST on
+# Polygon Amoy; production picks api.noah.com + USDC on Polygon.
+NOAH_ENVIRONMENT=sandbox
+# Server-only API key. Never expose it to the browser.
+NOAH_API_KEY=
+
+# ES384 private key (PEM, \n-escaped). Optional in sandbox when the API key was
+# created without a signing public key. MANDATORY in production:
+#   openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-384 -out noah_private.pem
+#   openssl pkey -in noah_private.pem -pubout -out noah_public.pem
+# Register noah_public.pem with the API key in Noah's dashboard.
+NOAH_SIGNING_PRIVATE_KEY=
+
+# Noah's webhook public key for this environment (from Noah's docs/dashboard).
+# Without it every webhook delivery is rejected as unsigned.
+NOAH_WEBHOOK_PUBLIC_KEY=

--- a/virtual-accounts/backend/.gitignore
+++ b/virtual-accounts/backend/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.env.local

--- a/virtual-accounts/backend/biome.json
+++ b/virtual-accounts/backend/biome.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["**", "!**/node_modules", "!**/dist", "!**/pnpm-lock.yaml"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "warn"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "es5",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "always"
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/virtual-accounts/backend/package.json
+++ b/virtual-accounts/backend/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "openfort-virtual-accounts-backend",
+  "version": "1.0.0",
+  "description": "Backend that issues Noah virtual bank accounts (USD ACH / EUR SEPA) against an Openfort embedded wallet",
+  "main": "dist/server.js",
+  "type": "module",
+  "packageManager": "pnpm@10.30.3",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "tsc && node --watch dist/server.js",
+    "check": "biome check --write .",
+    "lint": "biome lint .",
+    "format": "biome format --write ."
+  },
+  "dependencies": {
+    "@openfort/openfort-node": "^0.10.5",
+    "dotenv": "^16.6.1",
+    "express": "^5.1.0",
+    "express-rate-limit": "^7.5.0",
+    "jose": "^6.1.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.16",
+    "@types/express": "^5.0.4",
+    "@types/node": "^22.19.20",
+    "typescript": "^5.9.3"
+  },
+  "keywords": [
+    "openfort",
+    "noah",
+    "virtual-accounts",
+    "iban",
+    "ach",
+    "onramp"
+  ],
+  "author": "Openfort",
+  "license": "MIT"
+}

--- a/virtual-accounts/backend/package.json
+++ b/virtual-accounts/backend/package.json
@@ -9,6 +9,7 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "dev": "tsc && node --watch dist/server.js",
+    "test": "tsc && node --test \"dist/**/*.test.js\"",
     "check": "biome check --write .",
     "lint": "biome lint .",
     "format": "biome format --write ."

--- a/virtual-accounts/backend/src/config.ts
+++ b/virtual-accounts/backend/src/config.ts
@@ -20,7 +20,25 @@ export interface Config {
     /** Sandbox tokens carry a _TEST suffix. */
     cryptoCurrency: string
     network: string
+    /**
+     * Currencies hosted onboarding asks the customer to sign up for. Each one
+     * adds its entity's agreements to the flow — USD brings Noah's US banking
+     * partner — so onboarding a customer to an entity that cannot serve their
+     * country fails there, before any customer record exists.
+     */
+    fiatOptions: ('USD' | 'EUR')[]
   }
+}
+
+function parseFiatOptions(raw?: string): ('USD' | 'EUR')[] {
+  const parsed = (raw ?? 'USD,EUR')
+    .split(',')
+    .map((code) => code.trim().toUpperCase())
+    .filter((code): code is 'USD' | 'EUR' => code === 'USD' || code === 'EUR')
+  if (parsed.length === 0) {
+    throw new Error('NOAH_FIAT_OPTIONS must list at least one of USD, EUR.')
+  }
+  return parsed
 }
 
 function required(name: string): string {
@@ -72,6 +90,7 @@ export function loadConfig(): Config {
       webhookPublicKey: process.env.NOAH_WEBHOOK_PUBLIC_KEY?.replace(/\\n/g, '\n'),
       cryptoCurrency: isSandbox ? 'USDC_TEST' : 'USDC',
       network: isSandbox ? 'PolygonTestAmoy' : 'Polygon',
+      fiatOptions: parseFiatOptions(process.env.NOAH_FIAT_OPTIONS),
     },
   }
 }

--- a/virtual-accounts/backend/src/config.ts
+++ b/virtual-accounts/backend/src/config.ts
@@ -1,0 +1,77 @@
+export type NoahEnvironment = 'sandbox' | 'production'
+
+export interface Config {
+  port: number
+  allowedOrigins: string[]
+  /** HTTPS URL Noah's hosted KYC redirects back to. Use a tunnel locally. */
+  appUrl: string
+  openfort: {
+    secretKey: string
+    publishableKey: string
+  }
+  noah: {
+    environment: NoahEnvironment
+    apiKey: string
+    baseUrl: string
+    /** ES384 PEM. Optional in sandbox, required in production. */
+    signingPrivateKey?: string
+    /** Noah's webhook public key for this environment (PEM). */
+    webhookPublicKey?: string
+    /** Sandbox tokens carry a _TEST suffix. */
+    cryptoCurrency: string
+    network: string
+  }
+}
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(
+      `Missing required env var ${name}. Copy .env.local.example to .env.local and fill it in.`
+    )
+  }
+  return value
+}
+
+function parseOrigins(raw?: string): string[] {
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+}
+
+export function loadConfig(): Config {
+  const environment: NoahEnvironment =
+    process.env.NOAH_ENVIRONMENT === 'production' ? 'production' : 'sandbox'
+  const isSandbox = environment === 'sandbox'
+
+  const signingPrivateKey = process.env.NOAH_SIGNING_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!isSandbox && !signingPrivateKey) {
+    throw new Error(
+      'NOAH_SIGNING_PRIVATE_KEY is required in production — Noah signs every request.'
+    )
+  }
+
+  return {
+    port: Number.parseInt(process.env.PORT ?? '3021', 10),
+    allowedOrigins: parseOrigins(process.env.CORS_ORIGINS),
+    appUrl: required('PUBLIC_APP_URL'),
+    openfort: {
+      // Validates the user's session token only — the backend never signs transactions.
+      secretKey: required('OPENFORT_SECRET_KEY'),
+      // Required so iam.getSession can fetch the project JWKS to verify tokens.
+      publishableKey: required('OPENFORT_PUBLISHABLE_KEY'),
+    },
+    noah: {
+      environment,
+      // Server-only. Issues virtual accounts and reads customer state.
+      apiKey: required('NOAH_API_KEY'),
+      baseUrl: isSandbox ? 'https://api.sandbox.noah.com' : 'https://api.noah.com',
+      signingPrivateKey,
+      webhookPublicKey: process.env.NOAH_WEBHOOK_PUBLIC_KEY?.replace(/\\n/g, '\n'),
+      cryptoCurrency: isSandbox ? 'USDC_TEST' : 'USDC',
+      network: isSandbox ? 'PolygonTestAmoy' : 'Polygon',
+    },
+  }
+}

--- a/virtual-accounts/backend/src/noah.test.ts
+++ b/virtual-accounts/backend/src/noah.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mapVirtualAccount } from './noah.js'
+
+/**
+ * Both fixtures are real `POST /v1/workflows/bank-deposit-to-onchain-address`
+ * responses from api.sandbox.noah.com. The point of the test is the one thing
+ * that is easy to get wrong and expensive when wrong: `BankCode` is a routing
+ * number on ACH and Fedwire, and a BIC on SWIFT and SEPA.
+ */
+
+const usdResponse = {
+  AccountHolderName: 'John Mock-Doe',
+  AccountNumber: '239531098956',
+  BankCode: 'SSBAUS32',
+  BankName: 'SSB Bank',
+  Fee: { FiatCurrencyCode: 'USD', TotalFeeBase: '25', TotalFeePct: '0.15' },
+  PaymentMethodID: 'Bank/Swift/USD/SSBAUS32/239531098956/usr_test',
+  PaymentMethodType: 'BankSwift',
+  RelatedPaymentMethods: [
+    {
+      Details: { AccountNumber: '239531098956', BankCode: '043087080' },
+      Fee: { FiatCurrencyCode: 'USD', TotalFeeBase: '2.19', TotalFeePct: '0.15' },
+      PaymentMethodID: 'Bank/Ach/USD/043087080/239531098956/usr_test',
+      PaymentMethodType: 'BankAch',
+    },
+    {
+      Details: { AccountNumber: '239531098956', BankCode: '043087080' },
+      Fee: { FiatCurrencyCode: 'USD', TotalFeeBase: '20', TotalFeePct: '0.15' },
+      PaymentMethodID: 'Bank/Fedwire/USD/043087080/239531098956/usr_test',
+      PaymentMethodType: 'BankFedwire',
+    },
+  ],
+}
+
+const eurResponse = {
+  AccountHolderName: 'John Mock-Doe',
+  AccountNumber: 'MT62CFTE19870000000090010305349',
+  BankCode: 'CFTEMTM1XXX',
+  BankName: 'OPENPAYD FINANCIAL SERVICES MALTA LTD',
+  Fee: { FiatCurrencyCode: 'EUR', TotalFeeBase: '0', TotalFeePct: '1' },
+  PaymentMethodID: 'Bank/Sepa/EUR/CFTEMTM1XXX/MT62CFTE19870000000090010305349/usr_test',
+  PaymentMethodType: 'BankSepa',
+}
+
+test('a USD account exposes SWIFT, ACH and Fedwire with the right bank codes', () => {
+  const account = mapVirtualAccount(usdResponse, 'USD')
+
+  assert.deepEqual(
+    account.methods.map((m) => m.rail),
+    ['swift', 'ach', 'fedwire']
+  )
+  // The SWIFT BIC must never be offered as a routing number, and the routing
+  // number must not be dropped just because it arrived in a related method.
+  assert.equal(account.methods[0]?.bankCode, 'SSBAUS32')
+  assert.equal(account.methods[1]?.bankCode, '043087080')
+  assert.equal(account.methods[1]?.feeBase, '2.19')
+  assert.equal(account.currency, 'USD')
+})
+
+test('a EUR account is a single SEPA method with the IBAN as the account number', () => {
+  const account = mapVirtualAccount(eurResponse, 'EUR')
+
+  assert.deepEqual(
+    account.methods.map((m) => m.rail),
+    ['sepa']
+  )
+  assert.equal(account.methods[0]?.accountNumber, 'MT62CFTE19870000000090010305349')
+  assert.equal(account.methods[0]?.bankCode, 'CFTEMTM1XXX')
+  assert.equal(account.currency, 'EUR')
+})

--- a/virtual-accounts/backend/src/noah.ts
+++ b/virtual-accounts/backend/src/noah.ts
@@ -200,7 +200,11 @@ export function createNoahClient(config: Config) {
       }
     },
 
-    /** Hosted KYC. Request both fiat options so either rail can be issued later. */
+    /**
+     * Hosted KYC. Only ask for the currencies you can actually serve this
+     * customer: each one adds its entity's agreements to the flow, and an
+     * entity that cannot serve their country fails the session outright.
+     */
     async startOnboarding(customerId: string, returnUrl: string) {
       const session = await request<{ HostedURL: string }>(
         `/v1/onboarding/${encodeURIComponent(customerId)}`,
@@ -208,7 +212,7 @@ export function createNoahClient(config: Config) {
           method: 'POST',
           body: {
             ReturnURL: returnUrl,
-            FiatOptions: [{ FiatCurrencyCode: 'USD' }, { FiatCurrencyCode: 'EUR' }],
+            FiatOptions: config.noah.fiatOptions.map((code) => ({ FiatCurrencyCode: code })),
           },
         }
       )

--- a/virtual-accounts/backend/src/noah.ts
+++ b/virtual-accounts/backend/src/noah.ts
@@ -12,10 +12,7 @@ import type { Config } from './config.js'
 // ── Noah wire types (PascalCase, as the API returns them) ───────────────────
 
 interface NoahCustomer {
-  CustomerID: string
   Verifications?: { Status: 'Pending' | 'Approved' | 'Declined' }
-  FullName?: { FirstName: string; LastName: string }
-  Country?: string
 }
 
 interface NoahVirtualAccount {
@@ -25,7 +22,6 @@ interface NoahVirtualAccount {
   /** Routing number on ACH, BIC on SEPA. */
   BankCode: string
   BankName: string
-  BankAddress?: { City?: string; Country?: string; State?: string; Street?: string }
   PaymentMethodID: string
   PaymentMethodType: 'BankAch' | 'BankSepa' | string
   VirtualAccountID?: string
@@ -46,8 +42,6 @@ export interface VirtualAccount {
   /** BIC when `rail` is `sepa`. */
   bankCode: string
   bankName: string
-  bankCity?: string
-  bankCountry?: string
   /** Used by the sandbox deposit simulation. */
   paymentMethodId: string
 }
@@ -134,27 +128,18 @@ export function createNoahClient(config: Config) {
       accountNumber: va.AccountNumber,
       bankCode: va.BankCode,
       bankName: va.BankName,
-      bankCity: va.BankAddress?.City,
-      bankCountry: va.BankAddress?.Country,
       paymentMethodId: va.PaymentMethodID,
     }
   }
 
   return {
-    /** Current KYC state, or `null` when Noah has never seen this customer. */
-    async getCustomer(customerId: string) {
+    /** Current KYC status, or `null` when Noah has never seen this customer. */
+    async getCustomer(customerId: string): Promise<KycStatus | null> {
       try {
         const customer = await request<NoahCustomer>(
           `/v1/customers/${encodeURIComponent(customerId)}`
         )
-        return {
-          id: customer.CustomerID,
-          status: mapStatus(customer.Verifications?.Status),
-          fullName: customer.FullName
-            ? `${customer.FullName.FirstName} ${customer.FullName.LastName}`.trim()
-            : undefined,
-          country: customer.Country,
-        }
+        return mapStatus(customer.Verifications?.Status)
       } catch (error) {
         if (error instanceof NoahError && error.status === 404) return null
         throw error

--- a/virtual-accounts/backend/src/noah.ts
+++ b/virtual-accounts/backend/src/noah.ts
@@ -1,0 +1,251 @@
+import { createVerify } from 'node:crypto'
+import { importPKCS8, SignJWT } from 'jose'
+import type { Config } from './config.js'
+
+/**
+ * The whole Noah integration: signed HTTP client, the two endpoints this recipe
+ * needs, webhook verification, and the mapping into a rail-neutral shape.
+ *
+ * @see https://docs.noah.com/products/bank-onramp/
+ */
+
+// ── Noah wire types (PascalCase, as the API returns them) ───────────────────
+
+interface NoahCustomer {
+  CustomerID: string
+  Verifications?: { Status: 'Pending' | 'Approved' | 'Declined' }
+  FullName?: { FirstName: string; LastName: string }
+  Country?: string
+}
+
+interface NoahVirtualAccount {
+  AccountHolderName: string
+  /** Account number on ACH, IBAN on SEPA. */
+  AccountNumber: string
+  /** Routing number on ACH, BIC on SEPA. */
+  BankCode: string
+  BankName: string
+  BankAddress?: { City?: string; Country?: string; State?: string; Street?: string }
+  PaymentMethodID: string
+  PaymentMethodType: 'BankAch' | 'BankSepa' | string
+  VirtualAccountID?: string
+}
+
+// ── Rail-neutral shapes the frontend consumes ──────────────────────────────
+
+export type KycStatus = 'not_started' | 'pending' | 'approved' | 'declined'
+export type FiatCurrency = 'USD' | 'EUR'
+export type Rail = 'ach' | 'sepa'
+
+export interface VirtualAccount {
+  rail: Rail
+  currency: FiatCurrency
+  accountHolderName: string
+  /** IBAN when `rail` is `sepa`. */
+  accountNumber: string
+  /** BIC when `rail` is `sepa`. */
+  bankCode: string
+  bankName: string
+  bankCity?: string
+  bankCountry?: string
+  /** Used by the sandbox deposit simulation. */
+  paymentMethodId: string
+}
+
+export class NoahError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+    public body?: string
+  ) {
+    super(message)
+    this.name = 'NoahError'
+  }
+}
+
+export function createNoahClient(config: Config) {
+  const { apiKey, baseUrl, signingPrivateKey, cryptoCurrency, network } = config.noah
+  let cachedKey: CryptoKey | null = null
+
+  /**
+   * Noah verifies an ES384 JWT in the `Api-Signature` header. It is mandatory in
+   * production; in sandbox a key created without a registered public key
+   * authenticates on `X-Api-Key` alone, and sending an unregistered signature
+   * fails with 401 "public key not found".
+   */
+  async function sign(method: string, path: string, body?: string): Promise<string> {
+    if (!signingPrivateKey) throw new Error('NOAH_SIGNING_PRIVATE_KEY is not set')
+    if (!cachedKey) cachedKey = await importPKCS8(signingPrivateKey, 'ES384')
+
+    const url = new URL(`${baseUrl}${path}`)
+    const queryParams = url.search ? Object.fromEntries(url.searchParams.entries()) : undefined
+    let bodyHash: string | undefined
+    if (body) {
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(body))
+      bodyHash = Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('')
+    }
+
+    return new SignJWT({
+      method: method.toUpperCase(),
+      path: url.pathname,
+      ...(queryParams && { queryParams }),
+      ...(bodyHash && { bodyHash }),
+    })
+      .setProtectedHeader({ alg: 'ES384' })
+      .setAudience('https://api.noah.com')
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .sign(cachedKey)
+  }
+
+  async function request<T>(path: string, init: { method?: string; body?: unknown } = {}) {
+    const method = init.method ?? 'GET'
+    const body = init.body === undefined ? undefined : JSON.stringify(init.body)
+    const headers: Record<string, string> = {
+      'X-Api-Key': apiKey,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    }
+    if (signingPrivateKey) headers['Api-Signature'] = await sign(method, path, body)
+
+    const response = await fetch(`${baseUrl}${path}`, { method, headers, body })
+    const text = await response.text()
+    if (!response.ok) {
+      throw new NoahError(`Noah ${response.status} on ${method} ${path}`, response.status, text)
+    }
+    return (text ? JSON.parse(text) : {}) as T
+  }
+
+  function mapStatus(status?: string): KycStatus {
+    if (status === 'Approved') return 'approved'
+    if (status === 'Declined') return 'declined'
+    return 'pending'
+  }
+
+  function mapVirtualAccount(va: NoahVirtualAccount): VirtualAccount {
+    // The rail is the only thing that changes what the fields mean.
+    const rail: Rail = va.PaymentMethodType === 'BankSepa' ? 'sepa' : 'ach'
+    return {
+      rail,
+      currency: rail === 'sepa' ? 'EUR' : 'USD',
+      accountHolderName: va.AccountHolderName,
+      accountNumber: va.AccountNumber,
+      bankCode: va.BankCode,
+      bankName: va.BankName,
+      bankCity: va.BankAddress?.City,
+      bankCountry: va.BankAddress?.Country,
+      paymentMethodId: va.PaymentMethodID,
+    }
+  }
+
+  return {
+    /** Current KYC state, or `null` when Noah has never seen this customer. */
+    async getCustomer(customerId: string) {
+      try {
+        const customer = await request<NoahCustomer>(
+          `/v1/customers/${encodeURIComponent(customerId)}`
+        )
+        return {
+          id: customer.CustomerID,
+          status: mapStatus(customer.Verifications?.Status),
+          fullName: customer.FullName
+            ? `${customer.FullName.FirstName} ${customer.FullName.LastName}`.trim()
+            : undefined,
+          country: customer.Country,
+        }
+      } catch (error) {
+        if (error instanceof NoahError && error.status === 404) return null
+        throw error
+      }
+    },
+
+    /** Hosted KYC. Request both fiat options so either rail can be issued later. */
+    async startOnboarding(customerId: string, returnUrl: string) {
+      const session = await request<{ HostedURL: string }>(
+        `/v1/onboarding/${encodeURIComponent(customerId)}`,
+        {
+          method: 'POST',
+          body: {
+            ReturnURL: returnUrl,
+            FiatOptions: [{ FiatCurrencyCode: 'USD' }, { FiatCurrencyCode: 'EUR' }],
+          },
+        }
+      )
+      return { hostedUrl: session.HostedURL }
+    },
+
+    /**
+     * Bind a bank account to a wallet address. `USD` returns ACH details
+     * (routing + account number), `EUR` returns SEPA details (BIC + IBAN).
+     * Every deposit is converted to `cryptoCurrency` and sent to the address.
+     */
+    async createVirtualAccount(args: {
+      customerId: string
+      walletAddress: string
+      fiatCurrency: FiatCurrency
+    }) {
+      const account = await request<NoahVirtualAccount>(
+        '/v1/workflows/bank-deposit-to-onchain-address',
+        {
+          method: 'POST',
+          body: {
+            CustomerID: args.customerId,
+            FiatCurrency: args.fiatCurrency,
+            CryptoCurrency: cryptoCurrency,
+            Network: network,
+            DestinationAddress: { Address: args.walletAddress },
+          },
+        }
+      )
+      return mapVirtualAccount(account)
+    },
+
+    /** Sandbox only: pretend a bank transfer arrived, so the rest of the flow runs. */
+    async simulateDeposit(args: {
+      paymentMethodId: string
+      fiatAmount: string
+      fiatCurrency: FiatCurrency
+    }) {
+      await request('/v1/sandbox/fiat-deposit/simulate', {
+        method: 'POST',
+        body: {
+          PaymentMethodID: args.paymentMethodId,
+          FiatAmount: args.fiatAmount,
+          FiatCurrency: args.fiatCurrency,
+        },
+      })
+    },
+
+    /**
+     * Noah signs the raw body with ECDSA SHA-384 and sends the base64 signature
+     * in the `Webhook-Signature` header. Verify before parsing.
+     *
+     * @see https://docs.noah.com/api-concepts/webhooks/configuration/
+     */
+    verifyWebhook(rawBody: string, signature: string): boolean {
+      const key = config.noah.webhookPublicKey
+      if (!key || !signature) return false
+      try {
+        const verifier = createVerify('SHA384')
+        verifier.update(rawBody)
+        return verifier.verify(normalizePem(key), Buffer.from(signature, 'base64'))
+      } catch {
+        return false
+      }
+    },
+  }
+}
+
+export type NoahClient = ReturnType<typeof createNoahClient>
+
+/** Accepts a PEM pasted as a single line (as env vars usually are). */
+function normalizePem(key: string): string {
+  const body = key
+    .replace(/-----BEGIN PUBLIC KEY-----/g, '')
+    .replace(/-----END PUBLIC KEY-----/g, '')
+    .replace(/\s+/g, '')
+  const lines = body.match(/.{1,64}/g)?.join('\n') ?? body
+  return `-----BEGIN PUBLIC KEY-----\n${lines}\n-----END PUBLIC KEY-----`
+}

--- a/virtual-accounts/backend/src/noah.ts
+++ b/virtual-accounts/backend/src/noah.ts
@@ -15,15 +15,32 @@ interface NoahCustomer {
   Verifications?: { Status: 'Pending' | 'Approved' | 'Declined' }
 }
 
+interface NoahFee {
+  FiatCurrencyCode: string
+  TotalFeeBase: string
+  TotalFeePct: string
+}
+
 interface NoahVirtualAccount {
   AccountHolderName: string
-  /** Account number on ACH, IBAN on SEPA. */
+  /** Account number on ACH/Fedwire/SWIFT, IBAN on SEPA. */
   AccountNumber: string
-  /** Routing number on ACH, BIC on SEPA. */
+  /** Routing number on ACH/Fedwire, BIC on SWIFT/SEPA. */
   BankCode: string
   BankName: string
   PaymentMethodID: string
-  PaymentMethodType: 'BankAch' | 'BankSepa' | string
+  PaymentMethodType: string
+  Fee?: NoahFee
+  /**
+   * Other ways to pay the same account. A USD account comes back as SWIFT with
+   * ACH and Fedwire in here — same account number, different bank code and fee.
+   */
+  RelatedPaymentMethods?: {
+    Details: { AccountNumber: string; BankCode: string }
+    Fee?: NoahFee
+    PaymentMethodID: string
+    PaymentMethodType: string
+  }[]
   VirtualAccountID?: string
 }
 
@@ -31,18 +48,25 @@ interface NoahVirtualAccount {
 
 export type KycStatus = 'not_started' | 'pending' | 'approved' | 'declined'
 export type FiatCurrency = 'USD' | 'EUR'
-export type Rail = 'ach' | 'sepa'
+export type Rail = 'ach' | 'fedwire' | 'swift' | 'sepa'
+
+/** One way to pay into the account. `bankCode` means something different on each rail. */
+export interface BankMethod {
+  rail: Rail
+  /** IBAN on `sepa`, account number everywhere else. */
+  accountNumber: string
+  /** Routing number on `ach`/`fedwire`, BIC on `swift`/`sepa`. */
+  bankCode: string
+  feeBase?: string
+  feePct?: string
+}
 
 export interface VirtualAccount {
-  rail: Rail
   currency: FiatCurrency
   accountHolderName: string
-  /** IBAN when `rail` is `sepa`. */
-  accountNumber: string
-  /** BIC when `rail` is `sepa`. */
-  bankCode: string
   bankName: string
-  /** Used by the sandbox deposit simulation. */
+  /** Primary method first — the one the sandbox deposit simulation uses. */
+  methods: BankMethod[]
   paymentMethodId: string
 }
 
@@ -54,6 +78,56 @@ export class NoahError extends Error {
   ) {
     super(message)
     this.name = 'NoahError'
+  }
+}
+
+function mapStatus(status?: string): KycStatus {
+  if (status === 'Approved') return 'approved'
+  if (status === 'Declined') return 'declined'
+  return 'pending'
+}
+
+/**
+ * `BankCode` is a routing number on ACH/Fedwire and a BIC on SWIFT/SEPA, so
+ * the type is what decides how a field may be labeled. Never infer it from
+ * the currency you asked for: USD comes back as SWIFT, not ACH.
+ */
+function mapRail(paymentMethodType: string): Rail {
+  switch (paymentMethodType) {
+    case 'BankSepa':
+      return 'sepa'
+    case 'BankAch':
+      return 'ach'
+    case 'BankFedwire':
+      return 'fedwire'
+    default:
+      return 'swift'
+  }
+}
+
+export function mapVirtualAccount(va: NoahVirtualAccount, currency: FiatCurrency): VirtualAccount {
+  const methods: BankMethod[] = [
+    {
+      rail: mapRail(va.PaymentMethodType),
+      accountNumber: va.AccountNumber,
+      bankCode: va.BankCode,
+      feeBase: va.Fee?.TotalFeeBase,
+      feePct: va.Fee?.TotalFeePct,
+    },
+    ...(va.RelatedPaymentMethods ?? []).map((m) => ({
+      rail: mapRail(m.PaymentMethodType),
+      accountNumber: m.Details.AccountNumber,
+      bankCode: m.Details.BankCode,
+      feeBase: m.Fee?.TotalFeeBase,
+      feePct: m.Fee?.TotalFeePct,
+    })),
+  ]
+  return {
+    currency,
+    accountHolderName: va.AccountHolderName,
+    bankName: va.BankName,
+    methods,
+    paymentMethodId: va.PaymentMethodID,
   }
 }
 
@@ -112,26 +186,6 @@ export function createNoahClient(config: Config) {
     return (text ? JSON.parse(text) : {}) as T
   }
 
-  function mapStatus(status?: string): KycStatus {
-    if (status === 'Approved') return 'approved'
-    if (status === 'Declined') return 'declined'
-    return 'pending'
-  }
-
-  function mapVirtualAccount(va: NoahVirtualAccount): VirtualAccount {
-    // The rail is the only thing that changes what the fields mean.
-    const rail: Rail = va.PaymentMethodType === 'BankSepa' ? 'sepa' : 'ach'
-    return {
-      rail,
-      currency: rail === 'sepa' ? 'EUR' : 'USD',
-      accountHolderName: va.AccountHolderName,
-      accountNumber: va.AccountNumber,
-      bankCode: va.BankCode,
-      bankName: va.BankName,
-      paymentMethodId: va.PaymentMethodID,
-    }
-  }
-
   return {
     /** Current KYC status, or `null` when Noah has never seen this customer. */
     async getCustomer(customerId: string): Promise<KycStatus | null> {
@@ -162,8 +216,8 @@ export function createNoahClient(config: Config) {
     },
 
     /**
-     * Bind a bank account to a wallet address. `USD` returns ACH details
-     * (routing + account number), `EUR` returns SEPA details (BIC + IBAN).
+     * Bind a bank account to a wallet address. `USD` comes back as a SWIFT
+     * method with ACH and Fedwire alongside it; `EUR` as a single SEPA IBAN.
      * Every deposit is converted to `cryptoCurrency` and sent to the address.
      */
     async createVirtualAccount(args: {
@@ -184,7 +238,7 @@ export function createNoahClient(config: Config) {
           },
         }
       )
-      return mapVirtualAccount(account)
+      return mapVirtualAccount(account, args.fiatCurrency)
     },
 
     /** Sandbox only: pretend a bank transfer arrived, so the rest of the flow runs. */

--- a/virtual-accounts/backend/src/openfort.ts
+++ b/virtual-accounts/backend/src/openfort.ts
@@ -1,0 +1,32 @@
+import Openfort from '@openfort/openfort-node'
+import type { Request } from 'express'
+import type { Config } from './config.js'
+
+export type OpenfortClient = InstanceType<typeof Openfort>
+
+export function createOpenfortClient(config: Config): OpenfortClient {
+  // The publishable key is required so `iam.getSession` can fetch the project's
+  // JWKS and verify the user's access token. Without it, valid tokens fail with 401.
+  return new Openfort(config.openfort.secretKey, {
+    publishableKey: config.openfort.publishableKey,
+  })
+}
+
+/**
+ * Validate the Openfort access token on the Authorization header and return the
+ * user id. That id is used verbatim as the Noah `CustomerID`, so there is no
+ * user table to keep in sync — the wallet owner and the bank customer are one.
+ */
+export async function authenticate(
+  client: OpenfortClient,
+  request: Request
+): Promise<string | null> {
+  const token = request.headers.authorization?.replace('Bearer ', '')
+  if (!token) return null
+  try {
+    const { user } = await client.iam.getSession({ accessToken: token })
+    return user.id
+  } catch {
+    return null
+  }
+}

--- a/virtual-accounts/backend/src/routes.ts
+++ b/virtual-accounts/backend/src/routes.ts
@@ -134,8 +134,22 @@ export function createRoutes(config: Config, openfort: OpenfortClient, noah: Noa
         return
       }
 
+      // Act on `event.Data` here — credit a ledger, notify the user, and so on.
+      // Only literals are logged: the body is attacker-shaped until it is used.
       const event = JSON.parse(rawBody) as { EventType?: string; Data?: Record<string, unknown> }
-      console.log(`[noah webhook] ${event.EventType}`, event.Data)
+      switch (event.EventType) {
+        case 'Customer':
+          console.log('[noah webhook] KYC status changed')
+          break
+        case 'FiatDeposit':
+          console.log('[noah webhook] fiat deposit')
+          break
+        case 'Transaction':
+          console.log('[noah webhook] on-chain transaction')
+          break
+        default:
+          console.log('[noah webhook] unhandled event type')
+      }
       res.json({ received: true })
     },
   }

--- a/virtual-accounts/backend/src/routes.ts
+++ b/virtual-accounts/backend/src/routes.ts
@@ -1,0 +1,144 @@
+import type { Request, Response } from 'express'
+import type { Config } from './config.js'
+import { type FiatCurrency, type NoahClient, NoahError } from './noah.js'
+import { authenticate, type OpenfortClient } from './openfort.js'
+
+const CURRENCIES: FiatCurrency[] = ['USD', 'EUR']
+
+function parseCurrency(value: unknown): FiatCurrency | null {
+  return CURRENCIES.includes(value as FiatCurrency) ? (value as FiatCurrency) : null
+}
+
+function fail(res: Response, error: unknown, fallback: string) {
+  if (error instanceof NoahError) {
+    console.error(`[noah] ${error.message}`, error.body)
+    res.status(error.status === 404 ? 404 : 502).json({ error: fallback })
+    return
+  }
+  console.error(`[${fallback}]`, error)
+  res.status(500).json({ error: fallback })
+}
+
+export function createRoutes(config: Config, openfort: OpenfortClient, noah: NoahClient) {
+  /** Wraps a handler that needs an authenticated Openfort user. */
+  const withUser =
+    (handler: (req: Request, res: Response, customerId: string) => Promise<void>) =>
+    async (req: Request, res: Response) => {
+      const customerId = await authenticate(openfort, req)
+      if (!customerId) {
+        res.status(401).json({ error: 'Unauthorized' })
+        return
+      }
+      await handler(req, res, customerId)
+    }
+
+  return {
+    /** Current KYC status. `not_started` means Noah has never seen this user. */
+    getCustomer: withUser(async (_req, res, customerId) => {
+      try {
+        const customer = await noah.getCustomer(customerId)
+        res.json({ status: customer?.status ?? 'not_started', customer })
+      } catch (error) {
+        fail(res, error, 'Failed to read customer')
+      }
+    }),
+
+    /** Start hosted KYC, or report the status if the user already onboarded. */
+    startOnboarding: withUser(async (_req, res, customerId) => {
+      try {
+        const existing = await noah.getCustomer(customerId)
+        if (existing) {
+          res.json({ status: existing.status })
+          return
+        }
+        const { hostedUrl } = await noah.startOnboarding(
+          customerId,
+          `${config.appUrl}/?kyc=complete`
+        )
+        res.json({ status: 'pending', hostedUrl })
+      } catch (error) {
+        fail(res, error, 'Failed to start onboarding')
+      }
+    }),
+
+    /** Issue the bank account. `fiatCurrency` picks the rail: USD → ACH, EUR → SEPA. */
+    createVirtualAccount: withUser(async (req, res, customerId) => {
+      const { walletAddress, fiatCurrency } = req.body as {
+        walletAddress?: string
+        fiatCurrency?: string
+      }
+      if (!walletAddress || !/^0x[0-9a-fA-F]{40}$/.test(walletAddress)) {
+        res.status(400).json({ error: 'A valid walletAddress is required' })
+        return
+      }
+      const currency = parseCurrency(fiatCurrency)
+      if (!currency) {
+        res.status(400).json({ error: 'fiatCurrency must be USD or EUR' })
+        return
+      }
+
+      try {
+        const customer = await noah.getCustomer(customerId)
+        if (customer?.status !== 'approved') {
+          res.status(403).json({ error: 'Identity verification is not approved yet' })
+          return
+        }
+        const account = await noah.createVirtualAccount({
+          customerId,
+          walletAddress,
+          fiatCurrency: currency,
+        })
+        res.json({ account })
+      } catch (error) {
+        fail(res, error, 'Failed to issue virtual account')
+      }
+    }),
+
+    /** Sandbox only — production deposits arrive from a real bank transfer. */
+    simulateDeposit: withUser(async (req, res) => {
+      if (config.noah.environment !== 'sandbox') {
+        res.status(400).json({ error: 'Deposit simulation is sandbox-only' })
+        return
+      }
+      const { paymentMethodId, fiatAmount, fiatCurrency } = req.body as {
+        paymentMethodId?: string
+        fiatAmount?: string
+        fiatCurrency?: string
+      }
+      const currency = parseCurrency(fiatCurrency)
+      if (!paymentMethodId || !fiatAmount || !currency) {
+        res
+          .status(400)
+          .json({ error: 'paymentMethodId, fiatAmount and fiatCurrency (USD|EUR) are required' })
+        return
+      }
+
+      try {
+        await noah.simulateDeposit({ paymentMethodId, fiatAmount, fiatCurrency: currency })
+        res.json({ simulated: true })
+      } catch (error) {
+        fail(res, error, 'Failed to simulate deposit')
+      }
+    }),
+
+    /**
+     * Deposits settle asynchronously, so webhooks are how the app learns money
+     * moved: `FiatDeposit` when the transfer lands, `Transaction` when the crypto
+     * is sent on-chain, `Customer` when KYC changes.
+     */
+    webhook: (req: Request, res: Response) => {
+      const rawBody = req.body instanceof Buffer ? req.body.toString('utf8') : String(req.body)
+      const signature = req.header('Webhook-Signature') ?? ''
+
+      if (!noah.verifyWebhook(rawBody, signature)) {
+        console.error('[noah webhook] invalid or missing signature — rejected')
+        res.status(401).json({ error: 'Invalid signature' })
+        return
+      }
+
+      const event = JSON.parse(rawBody) as { EventType?: string; Data?: Record<string, unknown> }
+      console.log(`[noah webhook] ${event.EventType}`, event.Data)
+      res.json({ received: true })
+    },
+  }
+}

--- a/virtual-accounts/backend/src/routes.ts
+++ b/virtual-accounts/backend/src/routes.ts
@@ -36,8 +36,7 @@ export function createRoutes(config: Config, openfort: OpenfortClient, noah: Noa
     /** Current KYC status. `not_started` means Noah has never seen this user. */
     getCustomer: withUser(async (_req, res, customerId) => {
       try {
-        const customer = await noah.getCustomer(customerId)
-        res.json({ status: customer?.status ?? 'not_started', customer })
+        res.json({ status: (await noah.getCustomer(customerId)) ?? 'not_started' })
       } catch (error) {
         fail(res, error, 'Failed to read customer')
       }
@@ -48,7 +47,7 @@ export function createRoutes(config: Config, openfort: OpenfortClient, noah: Noa
       try {
         const existing = await noah.getCustomer(customerId)
         if (existing) {
-          res.json({ status: existing.status })
+          res.json({ status: existing })
           return
         }
         const { hostedUrl } = await noah.startOnboarding(
@@ -78,8 +77,7 @@ export function createRoutes(config: Config, openfort: OpenfortClient, noah: Noa
       }
 
       try {
-        const customer = await noah.getCustomer(customerId)
-        if (customer?.status !== 'approved') {
+        if ((await noah.getCustomer(customerId)) !== 'approved') {
           res.status(403).json({ error: 'Identity verification is not approved yet' })
           return
         }

--- a/virtual-accounts/backend/src/routes.ts
+++ b/virtual-accounts/backend/src/routes.ts
@@ -36,7 +36,12 @@ export function createRoutes(config: Config, openfort: OpenfortClient, noah: Noa
     /** Current KYC status. `not_started` means Noah has never seen this user. */
     getCustomer: withUser(async (_req, res, customerId) => {
       try {
-        res.json({ status: (await noah.getCustomer(customerId)) ?? 'not_started' })
+        // `fiatOptions` rides along so the UI only offers currencies this
+        // customer was actually onboarded for.
+        res.json({
+          status: (await noah.getCustomer(customerId)) ?? 'not_started',
+          fiatOptions: config.noah.fiatOptions,
+        })
       } catch (error) {
         fail(res, error, 'Failed to read customer')
       }

--- a/virtual-accounts/backend/src/server.ts
+++ b/virtual-accounts/backend/src/server.ts
@@ -1,0 +1,62 @@
+import { config as loadEnv } from 'dotenv'
+import express, { type NextFunction, type Request, type Response } from 'express'
+import rateLimit from 'express-rate-limit'
+import { loadConfig } from './config.js'
+import { createNoahClient } from './noah.js'
+import { createOpenfortClient } from './openfort.js'
+import { createRoutes } from './routes.js'
+
+loadEnv({ path: '.env.local' })
+
+const config = loadConfig()
+const openfort = createOpenfortClient(config)
+const noah = createNoahClient(config)
+const routes = createRoutes(config, openfort, noah)
+
+const app = express()
+
+// The webhook signature covers the RAW body, so it must not be parsed first.
+app.post('/api/banking/webhooks', express.raw({ type: '*/*' }), routes.webhook)
+app.use(express.json())
+
+app.use((req: Request, res: Response, next: NextFunction) => {
+  const origin = req.headers.origin
+  if (origin && config.allowedOrigins.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin)
+  } else if (config.allowedOrigins.length === 0) {
+    res.setHeader('Access-Control-Allow-Origin', '*')
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  if (req.method === 'OPTIONS') {
+    res.sendStatus(204)
+    return
+  }
+  next()
+})
+
+const writeLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  message: { error: 'Too many requests, try again later.' },
+})
+
+app.get('/api/health', (_req: Request, res: Response) => {
+  res.json({ status: 'ok', environment: config.noah.environment })
+})
+
+app.get('/api/banking/customer', routes.getCustomer)
+app.post('/api/banking/customer', writeLimiter, routes.startOnboarding)
+app.post('/api/banking/virtual-account', writeLimiter, routes.createVirtualAccount)
+app.post('/api/banking/simulate-deposit', writeLimiter, routes.simulateDeposit)
+
+app.use((_req: Request, res: Response) => {
+  res.status(404).json({ error: 'Not Found' })
+})
+
+app.listen(config.port, () => {
+  console.log(
+    `Virtual accounts backend listening on http://localhost:${config.port} (${config.noah.environment})`
+  )
+})

--- a/virtual-accounts/backend/src/server.ts
+++ b/virtual-accounts/backend/src/server.ts
@@ -15,8 +15,17 @@ const routes = createRoutes(config, openfort, noah)
 
 const app = express()
 
+// Every /api/banking route either authenticates a session or verifies a
+// signature, so all of them are rate-limited.
+const limiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  message: { error: 'Too many requests, try again later.' },
+})
+
 // The webhook signature covers the RAW body, so it must not be parsed first.
-app.post('/api/banking/webhooks', express.raw({ type: '*/*' }), routes.webhook)
+app.post('/api/banking/webhooks', limiter, express.raw({ type: '*/*' }), routes.webhook)
 app.use(express.json())
 
 app.use((req: Request, res: Response, next: NextFunction) => {
@@ -35,21 +44,14 @@ app.use((req: Request, res: Response, next: NextFunction) => {
   next()
 })
 
-const writeLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 60,
-  standardHeaders: true,
-  message: { error: 'Too many requests, try again later.' },
-})
-
 app.get('/api/health', (_req: Request, res: Response) => {
   res.json({ status: 'ok', environment: config.noah.environment })
 })
 
-app.get('/api/banking/customer', routes.getCustomer)
-app.post('/api/banking/customer', writeLimiter, routes.startOnboarding)
-app.post('/api/banking/virtual-account', writeLimiter, routes.createVirtualAccount)
-app.post('/api/banking/simulate-deposit', writeLimiter, routes.simulateDeposit)
+app.get('/api/banking/customer', limiter, routes.getCustomer)
+app.post('/api/banking/customer', limiter, routes.startOnboarding)
+app.post('/api/banking/virtual-account', limiter, routes.createVirtualAccount)
+app.post('/api/banking/simulate-deposit', limiter, routes.simulateDeposit)
 
 app.use((_req: Request, res: Response) => {
   res.status(404).json({ error: 'Not Found' })

--- a/virtual-accounts/backend/tsconfig.json
+++ b/virtual-accounts/backend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/virtual-accounts/frontend/.env.example
+++ b/virtual-accounts/frontend/.env.example
@@ -1,0 +1,17 @@
+# Openfort (client-safe) — Dashboard → API Keys / Embedded Wallet Keys
+VITE_OPENFORT_PUBLISHABLE_KEY=pk_test_...
+VITE_OPENFORT_SHIELD_KEY=...
+
+# Backend base URL (the Express service in ../backend)
+VITE_API_BASE_URL=http://localhost:3021
+
+# sandbox → Polygon Amoy + Noah's USDC_TEST · production → Polygon + USDC
+VITE_NOAH_ENVIRONMENT=sandbox
+
+# Token Noah delivers. Defaults match the environment above, override if needed.
+# Amoy USDC_TEST: 0xae1d7d8b36e9aba7d95a75c69d50b38e7e02a9dd
+# Polygon USDC:   0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359
+VITE_USDC_ADDRESS=
+
+# RPC override (optional)
+VITE_RPC_URL=

--- a/virtual-accounts/frontend/.env.example
+++ b/virtual-accounts/frontend/.env.example
@@ -8,10 +8,5 @@ VITE_API_BASE_URL=http://localhost:3021
 # sandbox → Polygon Amoy + Noah's USDC_TEST · production → Polygon + USDC
 VITE_NOAH_ENVIRONMENT=sandbox
 
-# Token Noah delivers. Defaults match the environment above, override if needed.
-# Amoy USDC_TEST: 0xae1d7d8b36e9aba7d95a75c69d50b38e7e02a9dd
-# Polygon USDC:   0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359
-VITE_USDC_ADDRESS=
-
-# RPC override (optional)
+# RPC override (optional — the default public endpoint rate-limits)
 VITE_RPC_URL=

--- a/virtual-accounts/frontend/.gitignore
+++ b/virtual-accounts/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+.env.local
+*.tsbuildinfo

--- a/virtual-accounts/frontend/biome.json
+++ b/virtual-accounts/frontend/biome.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "root": true,
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["**", "!**/node_modules", "!**/dist"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "a11y": {
+        "useButtonType": "off",
+        "noSvgWithoutTitle": "off"
+      },
+      "correctness": {
+        "useUniqueElementIds": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "es5",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "always"
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/virtual-accounts/frontend/index.html
+++ b/virtual-accounts/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Openfort · Virtual Bank Accounts</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/virtual-accounts/frontend/package.json
+++ b/virtual-accounts/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "openfort-virtual-accounts-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "packageManager": "pnpm@10.30.3",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "check": "biome check --write .",
+    "lint": "biome lint .",
+    "format": "biome format --write ."
+  },
+  "dependencies": {
+    "@openfort/react": "1.3.0",
+    "@tanstack/react-query": ">=5.45.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "viem": "^2.52.2",
+    "wagmi": "^3.6.16"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.16",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "typescript": "~5.9.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/virtual-accounts/frontend/src/App.tsx
+++ b/virtual-accounts/frontend/src/App.tsx
@@ -1,0 +1,55 @@
+import { AccountTypeEnum, useOpenfort, useUser } from '@openfort/react'
+import { useEthereumEmbeddedWallet } from '@openfort/react/ethereum'
+import type { CSSProperties } from 'react'
+import { useAccount } from 'wagmi'
+import { fontStack, muted } from './components/styles'
+import { Providers } from './openfort/Providers'
+import { Auth } from './screens/Auth'
+import { Dashboard } from './screens/Dashboard'
+import { WalletGate } from './screens/WalletGate'
+
+type Step = 'loading' | 'auth' | 'wallet' | 'dashboard'
+
+function useStep(): Step {
+  const { isLoading } = useOpenfort()
+  const { isAuthenticated } = useUser()
+  const { isConnected } = useAccount()
+  const wallet = useEthereumEmbeddedWallet()
+
+  if (isLoading) return 'loading'
+  if (!isAuthenticated) return 'auth'
+  if (wallet.status === 'fetching-wallets' || wallet.isConnecting) return 'loading'
+  if (!isConnected || wallet.activeWallet?.accountType !== AccountTypeEnum.EOA) return 'wallet'
+  return 'dashboard'
+}
+
+function Main() {
+  const step = useStep()
+  return (
+    <main style={pageStyle}>
+      <div style={{ width: '100%', maxWidth: 440 }}>
+        {step === 'loading' && <p style={muted}>Loading...</p>}
+        {step === 'auth' && <Auth />}
+        {step === 'wallet' && <WalletGate />}
+        {step === 'dashboard' && <Dashboard />}
+      </div>
+    </main>
+  )
+}
+
+export default function App() {
+  return (
+    <Providers>
+      <Main />
+    </Providers>
+  )
+}
+
+const pageStyle: CSSProperties = {
+  fontFamily: fontStack,
+  minHeight: '100vh',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 24,
+}

--- a/virtual-accounts/frontend/src/components/styles.ts
+++ b/virtual-accounts/frontend/src/components/styles.ts
@@ -1,0 +1,74 @@
+import type { CSSProperties } from 'react'
+
+export const fontStack = "'Manrope', 'Helvetica Neue', Arial, sans-serif"
+export const monoStack = "'Space Grotesk', 'Manrope', sans-serif"
+
+export const card: CSSProperties = {
+  background: 'var(--demo-surface)',
+  borderRadius: 'var(--radius-md)',
+  border: '1px solid var(--demo-border)',
+  padding: 22,
+  boxShadow: 'var(--demo-shadow)',
+  animation: 'va-rise .4s ease both',
+}
+
+export const primaryBtn: CSSProperties = {
+  background: '#FC3927',
+  color: '#fff',
+  borderRadius: 'var(--radius-md)',
+  padding: '10px 18px',
+  fontWeight: 600,
+  border: 'none',
+  fontFamily: fontStack,
+  fontSize: '0.9rem',
+  cursor: 'pointer',
+  width: '100%',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 8,
+}
+
+export const secondaryBtn: CSSProperties = {
+  ...primaryBtn,
+  background: 'var(--demo-surface-muted)',
+  color: 'var(--demo-ink-900)',
+  border: '1px solid var(--demo-border)',
+}
+
+export const input: CSSProperties = {
+  width: '100%',
+  padding: '10px 14px',
+  border: '1px solid var(--demo-border)',
+  borderRadius: 'var(--radius-md)',
+  fontFamily: monoStack,
+  fontSize: '0.95rem',
+  fontWeight: 500,
+  background: 'var(--demo-surface)',
+  color: 'var(--demo-ink-900)',
+  outline: 'none',
+}
+
+export const label: CSSProperties = {
+  fontSize: '0.7rem',
+  fontWeight: 600,
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+  color: 'var(--demo-ink-500)',
+  fontFamily: fontStack,
+}
+
+export const muted: CSSProperties = {
+  fontSize: '0.85rem',
+  color: 'var(--demo-ink-500)',
+  fontFamily: fontStack,
+  lineHeight: 1.5,
+  margin: 0,
+}
+
+export const errorText: CSSProperties = {
+  color: '#dc2626',
+  fontSize: '0.85rem',
+  fontFamily: fontStack,
+  margin: 0,
+}

--- a/virtual-accounts/frontend/src/index.css
+++ b/virtual-accounts/frontend/src/index.css
@@ -1,0 +1,50 @@
+@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap");
+
+:root {
+  --radius-md: 0.625rem;
+
+  --demo-bg: #f4f4f5;
+  --demo-surface: #ffffff;
+  --demo-surface-soft: #fafafa;
+  --demo-surface-muted: #f1f1f3;
+  --demo-border: #e4e4e7;
+
+  --demo-ink-900: #0a0a0a;
+  --demo-ink-700: #3f3f46;
+  --demo-ink-500: #71717a;
+  --demo-ink-400: #a1a1aa;
+
+  --demo-chip-bg: #f4f4f5;
+  --demo-chip-border: #e4e4e7;
+  --demo-shadow: 0 1px 3px rgba(15, 23, 42, 0.08), 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--demo-bg);
+  color: var(--demo-ink-900);
+  font-family: "Manrope", "Helvetica Neue", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+@keyframes va-rise {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes va-spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/virtual-accounts/frontend/src/lib/api.ts
+++ b/virtual-accounts/frontend/src/lib/api.ts
@@ -3,16 +3,23 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3021
 export type KycStatus = 'not_started' | 'pending' | 'approved' | 'declined'
 export type FiatCurrency = 'USD' | 'EUR'
 
+export type Rail = 'ach' | 'fedwire' | 'swift' | 'sepa'
+
+/** One way to pay into the account. USD accounts come back with three. */
+export interface BankMethod {
+  rail: Rail
+  accountNumber: string
+  bankCode: string
+  feeBase?: string
+  feePct?: string
+}
+
 /** Rail-neutral account, as the backend maps it out of Noah's response. */
 export interface VirtualAccount {
-  rail: 'ach' | 'sepa'
   currency: FiatCurrency
   accountHolderName: string
-  /** IBAN when `rail` is `sepa`. */
-  accountNumber: string
-  /** BIC when `rail` is `sepa`. */
-  bankCode: string
   bankName: string
+  methods: BankMethod[]
   paymentMethodId: string
 }
 
@@ -65,9 +72,22 @@ export const api = {
     }),
 }
 
-/** What each field is called on the rail the account was issued on. */
-export function railLabels(account: VirtualAccount) {
-  return account.rail === 'sepa'
-    ? { number: 'IBAN', code: 'BIC', rail: 'SEPA credit transfer' }
-    : { number: 'Account number', code: 'Routing number', rail: 'ACH or domestic wire' }
+/**
+ * What each field is called on a given rail. `bankCode` is a routing number on
+ * ACH and Fedwire but a BIC on SWIFT and SEPA — labeling it wrong sends a
+ * payer's money nowhere.
+ */
+export const RAIL_LABELS: Record<Rail, { title: string; number: string; code: string }> = {
+  ach: { title: 'ACH', number: 'Account number', code: 'Routing number' },
+  fedwire: { title: 'Domestic wire (Fedwire)', number: 'Account number', code: 'Routing number' },
+  swift: { title: 'International wire (SWIFT)', number: 'Account number', code: 'SWIFT / BIC' },
+  sepa: { title: 'SEPA credit transfer', number: 'IBAN', code: 'BIC' },
+}
+
+/** "$2.19 + 0.15%" — the difference between a cheap ACH and a $25 wire. */
+export function formatFee(method: BankMethod, currency: FiatCurrency) {
+  if (!method.feeBase) return undefined
+  const symbol = currency === 'EUR' ? '€' : '$'
+  const pct = method.feePct && method.feePct !== '0' ? ` + ${method.feePct}%` : ''
+  return `${symbol}${method.feeBase}${pct}`
 }

--- a/virtual-accounts/frontend/src/lib/api.ts
+++ b/virtual-accounts/frontend/src/lib/api.ts
@@ -13,8 +13,6 @@ export interface VirtualAccount {
   /** BIC when `rail` is `sepa`. */
   bankCode: string
   bankName: string
-  bankCity?: string
-  bankCountry?: string
   paymentMethodId: string
 }
 

--- a/virtual-accounts/frontend/src/lib/api.ts
+++ b/virtual-accounts/frontend/src/lib/api.ts
@@ -1,0 +1,75 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3021'
+
+export type KycStatus = 'not_started' | 'pending' | 'approved' | 'declined'
+export type FiatCurrency = 'USD' | 'EUR'
+
+/** Rail-neutral account, as the backend maps it out of Noah's response. */
+export interface VirtualAccount {
+  rail: 'ach' | 'sepa'
+  currency: FiatCurrency
+  accountHolderName: string
+  /** IBAN when `rail` is `sepa`. */
+  accountNumber: string
+  /** BIC when `rail` is `sepa`. */
+  bankCode: string
+  bankName: string
+  bankCity?: string
+  bankCountry?: string
+  paymentMethodId: string
+}
+
+export type GetAccessToken = () => Promise<string | null | undefined>
+
+async function call<T>(
+  path: string,
+  getAccessToken: GetAccessToken,
+  init: { method?: string; body?: unknown } = {}
+): Promise<T> {
+  const token = await getAccessToken()
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: init.method ?? 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+  })
+  const data = (await response.json().catch(() => ({}))) as T & { error?: string }
+  if (!response.ok) throw new Error(data.error ?? `Request failed (${response.status})`)
+  return data
+}
+
+export const api = {
+  getCustomer: (getAccessToken: GetAccessToken) =>
+    call<{ status: KycStatus }>('/api/banking/customer', getAccessToken),
+
+  startOnboarding: (getAccessToken: GetAccessToken) =>
+    call<{ status: KycStatus; hostedUrl?: string }>('/api/banking/customer', getAccessToken, {
+      method: 'POST',
+    }),
+
+  createVirtualAccount: (
+    getAccessToken: GetAccessToken,
+    body: { walletAddress: string; fiatCurrency: FiatCurrency }
+  ) =>
+    call<{ account: VirtualAccount }>('/api/banking/virtual-account', getAccessToken, {
+      method: 'POST',
+      body,
+    }),
+
+  simulateDeposit: (
+    getAccessToken: GetAccessToken,
+    body: { paymentMethodId: string; fiatAmount: string; fiatCurrency: FiatCurrency }
+  ) =>
+    call<{ simulated: true }>('/api/banking/simulate-deposit', getAccessToken, {
+      method: 'POST',
+      body,
+    }),
+}
+
+/** What each field is called on the rail the account was issued on. */
+export function railLabels(account: VirtualAccount) {
+  return account.rail === 'sepa'
+    ? { number: 'IBAN', code: 'BIC', rail: 'SEPA credit transfer' }
+    : { number: 'Account number', code: 'Routing number', rail: 'ACH or domestic wire' }
+}

--- a/virtual-accounts/frontend/src/lib/api.ts
+++ b/virtual-accounts/frontend/src/lib/api.ts
@@ -46,7 +46,10 @@ async function call<T>(
 
 export const api = {
   getCustomer: (getAccessToken: GetAccessToken) =>
-    call<{ status: KycStatus }>('/api/banking/customer', getAccessToken),
+    call<{ status: KycStatus; fiatOptions: FiatCurrency[] }>(
+      '/api/banking/customer',
+      getAccessToken
+    ),
 
   startOnboarding: (getAccessToken: GetAccessToken) =>
     call<{ status: KycStatus; hostedUrl?: string }>('/api/banking/customer', getAccessToken, {

--- a/virtual-accounts/frontend/src/main.tsx
+++ b/virtual-accounts/frontend/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App.tsx'
+import './index.css'
+
+// biome-ignore lint/style/noNonNullAssertion: #root is defined in index.html
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+)

--- a/virtual-accounts/frontend/src/openfort/Providers.tsx
+++ b/virtual-accounts/frontend/src/openfort/Providers.tsx
@@ -1,0 +1,50 @@
+import {
+  AccountTypeEnum,
+  AuthProvider,
+  ChainTypeEnum,
+  OpenfortProvider,
+  RecoveryMethod,
+} from '@openfort/react'
+import { OpenfortWagmiBridge } from '@openfort/react/wagmi'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { WagmiProvider } from 'wagmi'
+import { wagmiConfig } from './wagmi'
+
+const queryClient = new QueryClient()
+
+/**
+ * The wallet is a plain **EOA** with **passkey** recovery: it only has to
+ * receive the USDC Noah sends, and passkey recovery means no server-side
+ * encryption-session endpoint to run.
+ */
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <WagmiProvider config={wagmiConfig}>
+        <OpenfortWagmiBridge>
+          <OpenfortProvider
+            publishableKey={import.meta.env.VITE_OPENFORT_PUBLISHABLE_KEY}
+            walletConfig={{
+              chainType: ChainTypeEnum.EVM,
+              shieldPublishableKey: import.meta.env.VITE_OPENFORT_SHIELD_KEY,
+              ethereum: {
+                accountType: AccountTypeEnum.EOA,
+              },
+            }}
+            uiConfig={{
+              mode: 'light',
+              authProviders: [AuthProvider.EMAIL_OTP],
+              walletRecovery: {
+                allowedMethods: [RecoveryMethod.PASSKEY],
+                defaultMethod: RecoveryMethod.PASSKEY,
+              },
+            }}
+          >
+            {children}
+          </OpenfortProvider>
+        </OpenfortWagmiBridge>
+      </WagmiProvider>
+    </QueryClientProvider>
+  )
+}

--- a/virtual-accounts/frontend/src/openfort/wagmi.ts
+++ b/virtual-accounts/frontend/src/openfort/wagmi.ts
@@ -1,0 +1,28 @@
+import { getDefaultConfig } from '@openfort/react/wagmi'
+import { polygon, polygonAmoy } from 'viem/chains'
+import { createConfig, http } from 'wagmi'
+
+/** Noah settles sandbox deposits on Polygon Amoy and production ones on Polygon. */
+export const IS_SANDBOX = (import.meta.env.VITE_NOAH_ENVIRONMENT ?? 'sandbox') !== 'production'
+
+export const chain = IS_SANDBOX ? polygonAmoy : polygon
+
+/** The token Noah delivers: its USDC_TEST on Amoy, canonical USDC on Polygon. */
+export const USDC_ADDRESS = (import.meta.env.VITE_USDC_ADDRESS ||
+  (IS_SANDBOX
+    ? '0xae1d7d8b36e9aba7d95a75c69d50b38e7e02a9dd'
+    : '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359')) as `0x${string}`
+
+export const USDC_DECIMALS = 6
+
+export const EXPLORER_URL = IS_SANDBOX ? 'https://amoy.polygonscan.com' : 'https://polygonscan.com'
+
+export const wagmiConfig = createConfig(
+  getDefaultConfig({
+    appName: 'Openfort Virtual Accounts',
+    chains: [chain],
+    transports: {
+      [chain.id]: http(import.meta.env.VITE_RPC_URL || undefined),
+    },
+  })
+)

--- a/virtual-accounts/frontend/src/openfort/wagmi.ts
+++ b/virtual-accounts/frontend/src/openfort/wagmi.ts
@@ -8,10 +8,11 @@ export const IS_SANDBOX = (import.meta.env.VITE_NOAH_ENVIRONMENT ?? 'sandbox') !
 export const chain = IS_SANDBOX ? polygonAmoy : polygon
 
 /** The token Noah delivers: its USDC_TEST on Amoy, canonical USDC on Polygon. */
-export const USDC_ADDRESS = (import.meta.env.VITE_USDC_ADDRESS ||
-  (IS_SANDBOX
+export const USDC_ADDRESS = (
+  IS_SANDBOX
     ? '0xae1d7d8b36e9aba7d95a75c69d50b38e7e02a9dd'
-    : '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359')) as `0x${string}`
+    : '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+) as `0x${string}`
 
 export const USDC_DECIMALS = 6
 

--- a/virtual-accounts/frontend/src/screens/Auth.tsx
+++ b/virtual-accounts/frontend/src/screens/Auth.tsx
@@ -1,0 +1,100 @@
+import { useAuthCallback, useEmailOtpAuth } from '@openfort/react'
+import { type FormEvent, useState } from 'react'
+import { errorText, fontStack, input, muted, primaryBtn } from '../components/styles'
+
+/** Email OTP sign-in. The Openfort user id becomes the Noah customer id. */
+export function Auth() {
+  const { isLoading: isCallbackLoading } = useAuthCallback()
+  const { requestEmailOtp, signInEmailOtp, isLoading, isRequesting, error, reset } =
+    useEmailOtpAuth()
+  const [email, setEmail] = useState('')
+  const [otp, setOtp] = useState('')
+  const [otpSent, setOtpSent] = useState(false)
+
+  if (isCallbackLoading) return <p style={muted}>Verifying authentication...</p>
+
+  const handleRequest = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    await requestEmailOtp({ email })
+    setOtpSent(true)
+  }
+
+  const handleVerify = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    await signInEmailOtp({ email, otp })
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+      <div>
+        <h1 style={{ fontFamily: fontStack, fontSize: '1.2rem', margin: 0, fontWeight: 700 }}>
+          Your own bank account
+        </h1>
+        <p style={{ ...muted, marginTop: 6 }}>
+          Sign in to get a US account number or a European IBAN. Deposits arrive as USDC in your
+          wallet.
+        </p>
+      </div>
+
+      {otpSent ? (
+        <form onSubmit={handleVerify} style={formStyle}>
+          <p style={muted}>
+            We sent a code to <strong style={{ color: 'var(--demo-ink-900)' }}>{email}</strong>
+          </p>
+          <input
+            type="text"
+            inputMode="numeric"
+            placeholder="6-digit code"
+            value={otp}
+            onChange={(event) => setOtp(event.target.value)}
+            required
+            style={input}
+          />
+          {error && <p style={errorText}>{error.message}</p>}
+          <button type="submit" disabled={isLoading} style={btn(isLoading)}>
+            {isLoading ? 'Verifying...' : 'Verify'}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              reset()
+              setOtp('')
+              setOtpSent(false)
+            }}
+            style={linkBtn}
+          >
+            Use a different email
+          </button>
+        </form>
+      ) : (
+        <form onSubmit={handleRequest} style={formStyle}>
+          <input
+            type="email"
+            placeholder="you@company.com"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+            style={input}
+          />
+          {error && <p style={errorText}>{error.message}</p>}
+          <button type="submit" disabled={isRequesting} style={btn(isRequesting)}>
+            {isRequesting ? 'Sending...' : 'Continue with email'}
+          </button>
+        </form>
+      )}
+    </div>
+  )
+}
+
+const formStyle = { display: 'flex', flexDirection: 'column' as const, gap: 12 }
+
+const btn = (busy: boolean) => ({ ...primaryBtn, opacity: busy ? 0.6 : 1 })
+
+const linkBtn = {
+  background: 'none',
+  border: 'none',
+  fontSize: '0.85rem',
+  color: 'var(--demo-ink-500)',
+  cursor: 'pointer',
+  fontFamily: fontStack,
+}

--- a/virtual-accounts/frontend/src/screens/Dashboard.tsx
+++ b/virtual-accounts/frontend/src/screens/Dashboard.tsx
@@ -1,0 +1,306 @@
+import { useUser } from '@openfort/react'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { type CSSProperties, useState } from 'react'
+import { erc20Abi, formatUnits } from 'viem'
+import { useAccount, useReadContract } from 'wagmi'
+import {
+  card,
+  errorText,
+  fontStack,
+  input,
+  label,
+  monoStack,
+  muted,
+  primaryBtn,
+  secondaryBtn,
+} from '../components/styles'
+import { api, type FiatCurrency, railLabels, type VirtualAccount } from '../lib/api'
+import { chain, EXPLORER_URL, IS_SANDBOX, USDC_ADDRESS, USDC_DECIMALS } from '../openfort/wagmi'
+
+const CURRENCIES: FiatCurrency[] = ['USD', 'EUR']
+
+export function Dashboard() {
+  const { getAccessToken } = useUser()
+  const { address } = useAccount()
+  const [currency, setCurrency] = useState<FiatCurrency>('USD')
+  // One account per currency — issuing EUR does not replace the USD one.
+  const [accounts, setAccounts] = useState<Partial<Record<FiatCurrency, VirtualAccount>>>({})
+
+  const customer = useQuery({
+    queryKey: ['banking-customer'],
+    queryFn: () => api.getCustomer(getAccessToken),
+    // Hosted KYC finishes out of band, so poll while it is in flight.
+    refetchInterval: (query) => (query.state.data?.status === 'pending' ? 5000 : false),
+  })
+
+  const onboarding = useMutation({
+    mutationFn: () => api.startOnboarding(getAccessToken),
+    onSuccess: (result) => {
+      if (result.hostedUrl) window.location.assign(result.hostedUrl)
+      else customer.refetch()
+    },
+  })
+
+  const issue = useMutation({
+    mutationFn: () => {
+      if (!address) throw new Error('No wallet address')
+      return api.createVirtualAccount(getAccessToken, {
+        walletAddress: address,
+        fiatCurrency: currency,
+      })
+    },
+    onSuccess: ({ account }) => setAccounts((prev) => ({ ...prev, [account.currency]: account })),
+  })
+
+  const balance = useReadContract({
+    abi: erc20Abi,
+    address: USDC_ADDRESS,
+    functionName: 'balanceOf',
+    args: address ? [address] : undefined,
+    chainId: chain.id,
+    query: { enabled: Boolean(address), refetchInterval: 10_000 },
+  })
+
+  const account = accounts[currency]
+  const isApproved = customer.data?.status === 'approved'
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <header>
+        <h1 style={{ fontFamily: fontStack, fontSize: '1.2rem', margin: 0, fontWeight: 700 }}>
+          Virtual bank accounts
+        </h1>
+        <p style={{ ...muted, marginTop: 6 }}>
+          Deposits are converted to USDC and sent to your wallet on {chain.name}.
+        </p>
+      </header>
+
+      <section style={card}>
+        <span style={label}>Wallet balance</span>
+        <p
+          style={{
+            fontFamily: monoStack,
+            fontSize: '1.9rem',
+            fontWeight: 700,
+            margin: '6px 0 2px',
+          }}
+        >
+          {balance.data === undefined
+            ? '—'
+            : `${Number(formatUnits(balance.data, USDC_DECIMALS)).toFixed(2)} USDC`}
+        </p>
+        {address && (
+          <a
+            href={`${EXPLORER_URL}/address/${address}`}
+            target="_blank"
+            rel="noreferrer"
+            style={{ ...muted, fontFamily: monoStack, textDecoration: 'none' }}
+          >
+            {`${address.slice(0, 6)}...${address.slice(-4)}`} ↗
+          </a>
+        )}
+      </section>
+
+      <section style={card}>
+        <span style={label}>Identity</span>
+        {customer.isLoading ? (
+          <p style={{ ...muted, marginTop: 8 }}>Checking status...</p>
+        ) : isApproved ? (
+          <p style={{ ...muted, marginTop: 8 }}>
+            ✓ Verified with Noah — you can issue bank accounts.
+          </p>
+        ) : (
+          <>
+            <p style={{ ...muted, margin: '8px 0 12px' }}>
+              {customer.data?.status === 'pending'
+                ? 'Verification in progress. This page updates when Noah approves it.'
+                : 'Noah verifies your identity before issuing an account. This opens their hosted flow.'}
+            </p>
+            <button
+              type="button"
+              onClick={() => onboarding.mutate()}
+              disabled={onboarding.isPending}
+              style={{ ...primaryBtn, opacity: onboarding.isPending ? 0.6 : 1 }}
+            >
+              {onboarding.isPending ? 'Starting...' : 'Verify identity'}
+            </button>
+            {onboarding.error && <p style={errorText}>{onboarding.error.message}</p>}
+          </>
+        )}
+      </section>
+
+      <section style={card}>
+        <span style={label}>Currency</span>
+        <div style={{ display: 'flex', gap: 8, margin: '8px 0 16px' }}>
+          {CURRENCIES.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => setCurrency(option)}
+              style={toggleBtn(option === currency)}
+            >
+              {option === 'USD' ? 'USD · ACH' : 'EUR · SEPA'}
+            </button>
+          ))}
+        </div>
+
+        {account ? (
+          <AccountDetails account={account} />
+        ) : (
+          <>
+            <p style={{ ...muted, marginBottom: 12 }}>
+              {currency === 'USD'
+                ? 'A US account number and routing number in your name.'
+                : 'A European IBAN and BIC in your name.'}
+            </p>
+            <button
+              type="button"
+              onClick={() => issue.mutate()}
+              disabled={!isApproved || issue.isPending}
+              style={{ ...primaryBtn, opacity: !isApproved || issue.isPending ? 0.5 : 1 }}
+            >
+              {issue.isPending ? 'Issuing...' : `Get ${currency} bank details`}
+            </button>
+          </>
+        )}
+        {issue.error && <p style={{ ...errorText, marginTop: 10 }}>{issue.error.message}</p>}
+      </section>
+
+      {IS_SANDBOX && account && (
+        <SimulateDeposit account={account} onSimulated={() => balance.refetch()} />
+      )}
+    </div>
+  )
+}
+
+function AccountDetails({ account }: { account: VirtualAccount }) {
+  const labels = railLabels(account)
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <CopyField label={labels.code} value={account.bankCode} />
+      <CopyField label={labels.number} value={account.accountNumber} />
+      <dl style={{ margin: '6px 0 0', display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <Detail label="Account holder" value={account.accountHolderName} />
+        <Detail label="Bank" value={account.bankName} />
+        <Detail label="Transfer type" value={`${labels.rail} · ${account.currency}`} />
+      </dl>
+    </div>
+  )
+}
+
+function CopyField({ label: fieldLabel, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        await navigator.clipboard.writeText(value)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1500)
+      }}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+        width: '100%',
+        textAlign: 'left',
+        padding: '10px 12px',
+        borderRadius: 'var(--radius-md)',
+        border: '1px solid var(--demo-border)',
+        background: 'var(--demo-surface-soft)',
+        cursor: 'pointer',
+      }}
+    >
+      <span style={{ minWidth: 0 }}>
+        <span style={{ ...label, display: 'block' }}>{fieldLabel}</span>
+        <span
+          style={{
+            display: 'block',
+            fontFamily: monoStack,
+            fontSize: '0.95rem',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {value}
+        </span>
+      </span>
+      <span style={{ ...muted, fontSize: '0.75rem' }}>{copied ? '✓' : 'Copy'}</span>
+    </button>
+  )
+}
+
+function Detail({ label: name, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, ...muted }}>
+      <dt>{name}</dt>
+      <dd style={{ margin: 0, color: 'var(--demo-ink-900)' }}>{value}</dd>
+    </div>
+  )
+}
+
+/** Sandbox-only shortcut: Noah pretends a bank transfer landed and runs the real
+ * conversion path, so the wallet balance moves without a real transfer. */
+function SimulateDeposit({
+  account,
+  onSimulated,
+}: {
+  account: VirtualAccount
+  onSimulated: () => void
+}) {
+  const { getAccessToken } = useUser()
+  const [amount, setAmount] = useState('100')
+
+  const simulate = useMutation({
+    mutationFn: () =>
+      api.simulateDeposit(getAccessToken, {
+        paymentMethodId: account.paymentMethodId,
+        fiatAmount: amount,
+        fiatCurrency: account.currency,
+      }),
+    onSuccess: onSimulated,
+  })
+
+  return (
+    <section style={{ ...card, borderStyle: 'dashed' }}>
+      <span style={label}>Sandbox · simulate a deposit</span>
+      <div style={{ display: 'flex', gap: 8, margin: '10px 0 0' }}>
+        <input
+          type="number"
+          min="1"
+          value={amount}
+          onChange={(event) => setAmount(event.target.value)}
+          style={{ ...input, flex: 1 }}
+        />
+        <button
+          type="button"
+          onClick={() => simulate.mutate()}
+          disabled={simulate.isPending}
+          style={{ ...secondaryBtn, width: 'auto', opacity: simulate.isPending ? 0.6 : 1 }}
+        >
+          {simulate.isPending ? 'Sending...' : `Deposit ${account.currency}`}
+        </button>
+      </div>
+      {simulate.isSuccess && (
+        <p style={{ ...muted, marginTop: 10 }}>
+          Deposit accepted. Noah converts it and sends USDC — the balance updates shortly.
+        </p>
+      )}
+      {simulate.error && <p style={{ ...errorText, marginTop: 10 }}>{simulate.error.message}</p>}
+    </section>
+  )
+}
+
+const toggleBtn = (active: boolean): CSSProperties => ({
+  flex: 1,
+  padding: '8px 12px',
+  borderRadius: 'var(--radius-md)',
+  border: `1px solid ${active ? '#FC3927' : 'var(--demo-border)'}`,
+  background: active ? 'rgba(252,57,39,0.08)' : 'var(--demo-surface)',
+  color: active ? '#FC3927' : 'var(--demo-ink-700)',
+  fontFamily: fontStack,
+  fontSize: '0.85rem',
+  fontWeight: 600,
+  cursor: 'pointer',
+})

--- a/virtual-accounts/frontend/src/screens/Dashboard.tsx
+++ b/virtual-accounts/frontend/src/screens/Dashboard.tsx
@@ -14,7 +14,7 @@ import {
   primaryBtn,
   secondaryBtn,
 } from '../components/styles'
-import { api, type FiatCurrency, railLabels, type VirtualAccount } from '../lib/api'
+import { api, type FiatCurrency, formatFee, RAIL_LABELS, type VirtualAccount } from '../lib/api'
 import { chain, EXPLORER_URL, IS_SANDBOX, USDC_ADDRESS, USDC_DECIMALS } from '../openfort/wagmi'
 
 const CURRENCIES: FiatCurrency[] = ['USD', 'EUR']
@@ -150,8 +150,8 @@ export function Dashboard() {
           <>
             <p style={{ ...muted, marginBottom: 12 }}>
               {currency === 'USD'
-                ? 'A US account number and routing number in your name.'
-                : 'A European IBAN and BIC in your name.'}
+                ? 'A US account in your name, payable by ACH, domestic wire, or SWIFT.'
+                : 'A European IBAN in your name, payable by SEPA credit transfer.'}
             </p>
             <button
               type="button"
@@ -174,15 +174,26 @@ export function Dashboard() {
 }
 
 function AccountDetails({ account }: { account: VirtualAccount }) {
-  const labels = railLabels(account)
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-      <CopyField label={labels.code} value={account.bankCode} />
-      <CopyField label={labels.number} value={account.accountNumber} />
-      <dl style={{ margin: '6px 0 0', display: 'flex', flexDirection: 'column', gap: 4 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      {account.methods.map((method) => {
+        const labels = RAIL_LABELS[method.rail]
+        const fee = formatFee(method, account.currency)
+        return (
+          <div key={method.rail} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+              <span style={label}>{labels.title}</span>
+              {fee && <span style={{ ...muted, fontSize: '0.75rem' }}>fee {fee}</span>}
+            </div>
+            <CopyField label={labels.code} value={method.bankCode} />
+            <CopyField label={labels.number} value={method.accountNumber} />
+          </div>
+        )
+      })}
+      <dl style={{ margin: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
         <Detail label="Account holder" value={account.accountHolderName} />
         <Detail label="Bank" value={account.bankName} />
-        <Detail label="Transfer type" value={`${labels.rail} · ${account.currency}`} />
+        <Detail label="Currency" value={account.currency} />
       </dl>
     </div>
   )

--- a/virtual-accounts/frontend/src/screens/Dashboard.tsx
+++ b/virtual-accounts/frontend/src/screens/Dashboard.tsx
@@ -17,12 +17,10 @@ import {
 import { api, type FiatCurrency, formatFee, RAIL_LABELS, type VirtualAccount } from '../lib/api'
 import { chain, EXPLORER_URL, IS_SANDBOX, USDC_ADDRESS, USDC_DECIMALS } from '../openfort/wagmi'
 
-const CURRENCIES: FiatCurrency[] = ['USD', 'EUR']
-
 export function Dashboard() {
   const { getAccessToken } = useUser()
   const { address } = useAccount()
-  const [currency, setCurrency] = useState<FiatCurrency>('USD')
+  const [picked, setPicked] = useState<FiatCurrency | null>(null)
   // One account per currency — issuing EUR does not replace the USD one.
   const [accounts, setAccounts] = useState<Partial<Record<FiatCurrency, VirtualAccount>>>({})
 
@@ -61,8 +59,13 @@ export function Dashboard() {
     query: { enabled: Boolean(address), refetchInterval: 10_000 },
   })
 
-  const account = accounts[currency]
   const isApproved = customer.data?.status === 'approved'
+  // Only the currencies this backend onboards customers for can be issued, so
+  // a stale pick (or the first render) falls back to the first one offered.
+  const currencies = customer.data?.fiatOptions ?? []
+  const currency: FiatCurrency =
+    picked && currencies.includes(picked) ? picked : (currencies[0] ?? 'USD')
+  const account = accounts[currency]
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -132,14 +135,14 @@ export function Dashboard() {
       <section style={card}>
         <span style={label}>Currency</span>
         <div style={{ display: 'flex', gap: 8, margin: '8px 0 16px' }}>
-          {CURRENCIES.map((option) => (
+          {currencies.map((option) => (
             <button
               key={option}
               type="button"
-              onClick={() => setCurrency(option)}
+              onClick={() => setPicked(option)}
               style={toggleBtn(option === currency)}
             >
-              {option === 'USD' ? 'USD · ACH' : 'EUR · SEPA'}
+              {option === 'USD' ? 'USD · ACH, wire' : 'EUR · SEPA'}
             </button>
           ))}
         </div>
@@ -181,7 +184,9 @@ function AccountDetails({ account }: { account: VirtualAccount }) {
         const fee = formatFee(method, account.currency)
         return (
           <div key={method.rail} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+            <div
+              style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}
+            >
               <span style={label}>{labels.title}</span>
               {fee && <span style={{ ...muted, fontSize: '0.75rem' }}>fee {fee}</span>}
             </div>

--- a/virtual-accounts/frontend/src/screens/WalletGate.tsx
+++ b/virtual-accounts/frontend/src/screens/WalletGate.tsx
@@ -1,0 +1,80 @@
+import { AccountTypeEnum, RecoveryMethod } from '@openfort/react'
+import { useEthereumEmbeddedWallet } from '@openfort/react/ethereum'
+import { useState } from 'react'
+import { errorText, fontStack, muted, primaryBtn } from '../components/styles'
+
+/**
+ * Creates (or passkey-recovers) the EOA that Noah will deliver USDC to. This is
+ * the address bound to the virtual account, so it has to exist before the
+ * account is issued.
+ */
+export function WalletGate() {
+  const wallet = useEthereumEmbeddedWallet()
+  const [error, setError] = useState<string | null>(null)
+
+  const eoaWallets = (wallet.wallets ?? []).filter(
+    (w) => w.accountType === AccountTypeEnum.EOA && w.isAvailable !== false
+  )
+  const existing = eoaWallets[0]
+  const busy = wallet.status === 'creating' || wallet.isConnecting
+  const walletError = wallet.status === 'error' ? wallet.error : null
+
+  const run = async (action: () => Promise<unknown>) => {
+    setError(null)
+    try {
+      await action()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Wallet setup failed')
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div>
+        <h1 style={{ fontFamily: fontStack, fontSize: '1.2rem', margin: 0, fontWeight: 700 }}>
+          {existing ? 'Unlock your wallet' : 'Create your wallet'}
+        </h1>
+        <p style={{ ...muted, marginTop: 6 }}>
+          A self-custodial EOA secured by a passkey. Every deposit to your bank account is converted
+          and sent here.
+        </p>
+      </div>
+
+      {existing ? (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() =>
+            run(() =>
+              wallet.setActive({
+                address: existing.address,
+                recoveryMethod: RecoveryMethod.PASSKEY,
+              })
+            )
+          }
+          style={{ ...primaryBtn, opacity: busy ? 0.6 : 1 }}
+        >
+          {busy ? 'Unlocking...' : 'Unlock with passkey'}
+        </button>
+      ) : (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() =>
+            run(() =>
+              wallet.create({
+                accountType: AccountTypeEnum.EOA,
+                recoveryMethod: RecoveryMethod.PASSKEY,
+              })
+            )
+          }
+          style={{ ...primaryBtn, opacity: busy ? 0.6 : 1 }}
+        >
+          {busy ? 'Creating...' : 'Create wallet with passkey'}
+        </button>
+      )}
+
+      {(error || walletError) && <p style={errorText}>{error ?? walletError}</p>}
+    </div>
+  )
+}

--- a/virtual-accounts/frontend/src/screens/WalletGate.tsx
+++ b/virtual-accounts/frontend/src/screens/WalletGate.tsx
@@ -1,80 +1,72 @@
 import { AccountTypeEnum, RecoveryMethod } from '@openfort/react'
 import { useEthereumEmbeddedWallet } from '@openfort/react/ethereum'
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { errorText, fontStack, muted, primaryBtn } from '../components/styles'
 
 /**
- * Creates (or passkey-recovers) the EOA that Noah will deliver USDC to. This is
- * the address bound to the virtual account, so it has to exist before the
- * account is issued.
+ * Brings up the EOA that Noah delivers USDC to: recovers the existing one, or
+ * creates it on first sign-in. Runs on its own — the only button here is the
+ * retry after a failure, since the passkey prompt can be dismissed.
  */
 export function WalletGate() {
   const wallet = useEthereumEmbeddedWallet()
   const [error, setError] = useState<string | null>(null)
+  const started = useRef(false)
 
-  const eoaWallets = (wallet.wallets ?? []).filter(
+  const { wallets, status, isConnecting, create, setActive } = wallet
+  const existing = (wallets ?? []).find(
     (w) => w.accountType === AccountTypeEnum.EOA && w.isAvailable !== false
   )
-  const existing = eoaWallets[0]
-  const busy = wallet.status === 'creating' || wallet.isConnecting
-  const walletError = wallet.status === 'error' ? wallet.error : null
 
-  const run = async (action: () => Promise<unknown>) => {
+  const setUpWallet = useCallback(async () => {
     setError(null)
     try {
-      await action()
+      if (existing) {
+        await setActive({ address: existing.address, recoveryMethod: RecoveryMethod.PASSKEY })
+      } else {
+        await create({ accountType: AccountTypeEnum.EOA, recoveryMethod: RecoveryMethod.PASSKEY })
+      }
     } catch (err) {
+      started.current = false // let the user retry a dismissed passkey prompt
       setError(err instanceof Error ? err.message : 'Wallet setup failed')
     }
-  }
+  }, [existing, create, setActive])
+
+  useEffect(() => {
+    // Wait for the wallet list before deciding between recover and create.
+    if (started.current || status === 'fetching-wallets' || isConnecting) return
+    started.current = true
+    void setUpWallet()
+  }, [status, isConnecting, setUpWallet])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-      <div>
-        <h1 style={{ fontFamily: fontStack, fontSize: '1.2rem', margin: 0, fontWeight: 700 }}>
-          {existing ? 'Unlock your wallet' : 'Create your wallet'}
-        </h1>
-        <p style={{ ...muted, marginTop: 6 }}>
-          A self-custodial EOA secured by a passkey. Every deposit to your bank account is converted
-          and sent here.
-        </p>
-      </div>
-
-      {existing ? (
-        <button
-          type="button"
-          disabled={busy}
-          onClick={() =>
-            run(() =>
-              wallet.setActive({
-                address: existing.address,
-                recoveryMethod: RecoveryMethod.PASSKEY,
-              })
-            )
-          }
-          style={{ ...primaryBtn, opacity: busy ? 0.6 : 1 }}
-        >
-          {busy ? 'Unlocking...' : 'Unlock with passkey'}
-        </button>
-      ) : (
-        <button
-          type="button"
-          disabled={busy}
-          onClick={() =>
-            run(() =>
-              wallet.create({
-                accountType: AccountTypeEnum.EOA,
-                recoveryMethod: RecoveryMethod.PASSKEY,
-              })
-            )
-          }
-          style={{ ...primaryBtn, opacity: busy ? 0.6 : 1 }}
-        >
-          {busy ? 'Creating...' : 'Create wallet with passkey'}
-        </button>
+      <p style={muted}>
+        {error
+          ? 'Confirm the passkey prompt to unlock your wallet.'
+          : existing
+            ? 'Unlocking your wallet with your passkey...'
+            : 'Creating your wallet...'}
+      </p>
+      {error && (
+        <>
+          <p style={errorText}>{error}</p>
+          <button
+            type="button"
+            onClick={() => {
+              started.current = true
+              void setUpWallet()
+            }}
+            style={primaryBtn}
+          >
+            Try again
+          </button>
+        </>
       )}
-
-      {(error || walletError) && <p style={errorText}>{error ?? walletError}</p>}
+      <p style={{ ...muted, fontFamily: fontStack, fontSize: '0.78rem' }}>
+        A self-custodial EOA secured by a passkey. Deposits to your bank account are converted and
+        sent here.
+      </p>
     </div>
   )
 }

--- a/virtual-accounts/frontend/src/vite-env.d.ts
+++ b/virtual-accounts/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/virtual-accounts/frontend/tsconfig.app.json
+++ b/virtual-accounts/frontend/tsconfig.app.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/virtual-accounts/frontend/tsconfig.json
+++ b/virtual-accounts/frontend/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/virtual-accounts/frontend/tsconfig.node.json
+++ b/virtual-accounts/frontend/tsconfig.node.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/virtual-accounts/frontend/vite.config.ts
+++ b/virtual-accounts/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  // Dedicated port so it doesn't collide with other recipe dev servers.
+  // `host: true` lets a tunnel (needed for Noah's hosted KYC) reach it.
+  server: { host: true, port: 5182, strictPort: true },
+})

--- a/virtual-accounts/frontend/vite.config.ts
+++ b/virtual-accounts/frontend/vite.config.ts
@@ -5,6 +5,12 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [react()],
   // Dedicated port so it doesn't collide with other recipe dev servers.
-  // `host: true` lets a tunnel (needed for Noah's hosted KYC) reach it.
-  server: { host: true, port: 5182, strictPort: true },
+  // Noah's hosted KYC needs an HTTPS return URL, so dev runs behind a tunnel:
+  // `host: true` binds it, and the allowlist stops Vite 403-ing the tunnel host.
+  server: {
+    host: true,
+    port: 5182,
+    strictPort: true,
+    allowedHosts: ['.trycloudflare.com', '.ngrok.app', '.ngrok-free.app', '.ngrok.io'],
+  },
 })


### PR DESCRIPTION
Issues each user their own bank account details — a US routing/account number (ACH and wire) or a European IBAN (SEPA) — from an Openfort embedded wallet. Fiat deposited to the account is converted to USDC and settled on-chain to that wallet.

## What's in it

- `backend/` — Express. Validates the Openfort session token, then calls Noah with a server-only API key: hosted KYC, the virtual-account workflow, sandbox deposit simulation, and a signature-verified webhook route.
- `frontend/` — Vite + React. Openfort embedded EOA with passkey recovery on Polygon Amoy, KYC gate, USD/EUR toggle, account details with per-rail labels, deposit simulation, USDC balance.

The Openfort user id is used verbatim as the Noah `CustomerID`, so there is no user table to keep in sync.

## Both rails from one call

`FiatCurrency` is the only field that changes. The response's `PaymentMethodType` (`BankAch` / `BankSepa`) decides whether `AccountNumber` is an account number or an IBAN and whether `BankCode` is a routing number or a BIC — the adapter maps that into a `rail` field rather than assuming from the request.

## Notes

- Request signing is applied whenever `NOAH_SIGNING_PRIVATE_KEY` is set. Noah requires it in production; in sandbox a signature from an unregistered key fails with `401 "public key not found"`.
- The webhook route mounts `express.raw` before `express.json()` — the signature covers the exact bytes Noah sent.
- Hosted KYC needs an HTTPS `PUBLIC_APP_URL`, so local development needs a tunnel. README covers it.

## Verified

- `pnpm build` clean on both packages (tsc + vite), `pnpm check` clean (Biome).
- Backend smoke-tested live against `api.sandbox.noah.com`: health ok, unknown customer returns 404 (mapped to `not_started`), every `/api/banking/*` route returns 401 without an Openfort bearer, webhook returns 401 on a bad signature.
- Not exercised end to end: issuing an account needs a Noah-approved customer, which requires completing the hosted KYC flow behind a tunnel.

Docs page for this recipe: openfort-xyz/documentation (Recipes → Funding → Virtual bank accounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)